### PR TITLE
[Feat] 최신 뉴스 영역 구현

### DIFF
--- a/current-news/index.css
+++ b/current-news/index.css
@@ -6,7 +6,58 @@
     word-break: keep-all;
 }
 .current-news__headline {
+    max-width: 360px;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+
+    position: absolute;
+}
+
+.current-news__rolling-box {
+    height: 17px;
+    width: 100%;
+    position: relative;
+    overflow: hidden;
+}
+
+.current-news__disappear-text {
+    opacity: 0;
+    top: 0px;
+}
+.current-news__appear-text {
+    top: 17px;
+}
+
+.current-news__not-display {
+    opacity: 0;
+}
+
+.rolling-in {
+    animation-name: rolling-in;
+    animation-duration: 1s;
+    animation-delay: 0.3s;
+}
+.rolling-out {
+    animation-name: rolling-out;
+    animation-duration: 1s;
+}
+
+@keyframes rolling-in {
+    from {
+        top: 17px;
+    }
+    to {
+        top: 0px;
+    }
+}
+@keyframes rolling-out {
+    from {
+        opacity: 1;
+        top: 0px;
+    }
+    to {
+        opacity: 1;
+        top: -17px;
+    }
 }

--- a/current-news/index.css
+++ b/current-news/index.css
@@ -1,0 +1,12 @@
+.current-news__box {
+    padding: 16px;
+    width: 461px;
+}
+.current-news__media-title {
+    word-break: keep-all;
+}
+.current-news__headline {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}

--- a/current-news/index.js
+++ b/current-news/index.js
@@ -1,0 +1,16 @@
+import { CURRENT_NEWS } from '../static/data/current-news.js'
+import { rolling } from './rolling.js';
+
+function initCurrentNews() {
+    const currentNewsBoxDOMs = document.querySelectorAll('.current-news__box');
+    
+    currentNewsBoxDOMs.forEach((newsBoxDOM, idx) => {
+        const mediaTitleDOM = newsBoxDOM.querySelector('.current-news__media-title');
+        const rollingBoxDOM = newsBoxDOM.querySelector('.current-news__rolling-box');
+
+        mediaTitleDOM.innerText = CURRENT_NEWS.data[idx].media;
+        rolling(rollingBoxDOM, CURRENT_NEWS.data[idx])
+    });
+}
+
+initCurrentNews();

--- a/current-news/rolling.js
+++ b/current-news/rolling.js
@@ -1,0 +1,44 @@
+import { getNextNumber } from "../utils/getNextNumber.js";
+
+/**
+ * @description 최신 뉴스 DOM의 텍스트를 rolling 해주는 함수
+ */
+export function rolling(rollingBoxDOM, rollingData) {
+    const length = rollingData.length;
+
+    const staticTextDOM = rollingBoxDOM.querySelector('.current-news__static-text');
+    const disappearTextDOM = rollingBoxDOM.querySelector('.current-news__disappear-text');
+    const appearTextDOM = rollingBoxDOM.querySelector('.current-news__appear-text');
+
+    staticTextDOM.innerText = rollingData.newsList[0].title;
+
+    if (length === 1) {
+        return;
+    }
+
+    let prevIdx = 0, nextIdx = 1;
+    disappearTextDOM.innerText = rollingData.newsList[prevIdx].title;
+    appearTextDOM.innerText = rollingData.newsList[nextIdx].title;
+    
+    setInterval(() => {
+        // rolling 애니메이션 실행
+        staticTextDOM.classList.add('current-news__not-display')
+        disappearTextDOM.classList.add('rolling-out');
+        appearTextDOM.classList.add('rolling-in');
+
+        staticTextDOM.innerText = rollingData.newsList[nextIdx].title;
+
+        // 다음 rolling 애니메이션을 위해 초기화
+        prevIdx = getNextNumber(prevIdx, length);
+        nextIdx = getNextNumber(nextIdx, length);
+
+        setTimeout(() => {
+            staticTextDOM.classList.remove('current-news__not-display');
+            disappearTextDOM.classList.remove('rolling-out');
+            appearTextDOM.classList.remove('rolling-in');
+
+            disappearTextDOM.innerText = rollingData.newsList[prevIdx].title;
+            appearTextDOM.innerText = rollingData.newsList[nextIdx].title;        
+        }, 1200);
+    }, 5000);
+}

--- a/global-css/components.css
+++ b/global-css/components.css
@@ -1,5 +1,6 @@
 .border {
     border: 1px solid var(--gray100);
+    box-sizing: border-box;
 }
 
 .flexbox__space-between--center {
@@ -10,6 +11,10 @@
 .flexbox__flex-start--center {
     display: flex;
     align-items: center;
+}
+.flexbox__column-direction {
+    display: flex;
+    flex-direction: column;
 }
 
 .gap8 {
@@ -23,6 +28,9 @@
 }
 .gap32 {
     gap: 32px;
+}
+.gap40 {
+    gap: 40px;
 }
 .gap48 {
     gap: 48px;

--- a/global-css/token.css
+++ b/global-css/token.css
@@ -78,22 +78,16 @@
     color: var(--blue500);
 }
 .surface--default {
-    color: var(--white);
+    background-color: var(--white);
 }
 .surface--alt {
-    color: var(--gray50);
+    background-color: var(--gray50);
 }
 .surface__brand--default {
-    color: var(--blue500);
+    background-color: var(--blue500);
 }
 .surface__brand--alt {
-    color: var(--blue100);
-}
-.border--bold {
-    color: var(--gray300);
-}
-.border--default {
-    color: var(--gray100);
+    background-color: var(--blue100);
 }
 
 @font-face {

--- a/header/getCurrentDate.js
+++ b/header/getCurrentDate.js
@@ -1,5 +1,10 @@
 import { formatNumberDigit } from "../utils/format.js";
 
+/**
+ * @description 현재 날짜를 포맷해서 반환해주는 함수
+ * 
+ * @returns 2024. 07. 02. 화요일
+ */
 export function getCurrentDate() {
     const days = ['일', '월', '화', '수', '목', '금', '토']
     const date = new Date();

--- a/index.css
+++ b/index.css
@@ -1,3 +1,4 @@
 @import url("global-css/reset.css");
 @import url("global-css/token.css");
 @import url("global-css/components.css");
+@import url("current-news/index.css");

--- a/index.html
+++ b/index.html
@@ -17,17 +17,25 @@
             <p id="header__current-date" class="text__medium16 text--default"></p>
         </section>
     </header>
-    
+
     <main>
         <section class="flexbox__flex-start--center gap8">
-            <article class="current-news__box surface--alt border flexbox__flex-start--center gap16">
-                <p class="current-news__media-title text--strong">데일리뉴스</p>
-                <p class="current-news__headline text--default">[1보] 김기현·안철수·천하람·황교안, 與전대 본경선 진출진출진출</p>
-            </article>
-            <article class="current-news__box surface--alt border flexbox__flex-start--center gap16">
-                <p class="current-news__media-title text--strong">연합뉴스</p>
-                <p class="current-news__headline text--default">[1보] 김기현·안철수·천하람·황교안, 與전대 본경선 진출</p>
-            </article>
+            <section class="current-news__box surface--alt border flexbox__flex-start--center gap16">
+                <p class="current-news__media-title text--strong text__bold14"></p>
+                <section class="current-news__rolling-box">
+                    <p class="current-news__disappear-text current-news__headline text--default text__medium14"></p>
+                    <p class="current-news__appear-text current-news__headline text--default text__medium14"></p>
+                    <p class="current-news__static-text current-news__headline text--default text__medium14"></p>
+                </section>
+            </section>
+            <section class="current-news__box surface--alt border flexbox__flex-start--center gap16">
+                <p class="current-news__media-title text--strong text__bold14"></p>
+                <section class="current-news__rolling-box">
+                    <p class="current-news__disappear-text current-news__headline text--default text__medium14"></p>
+                    <p class="current-news__appear-text current-news__headline text--default text__medium14"></p>
+                    <p class="current-news__static-text current-news__headline text--default text__medium14"></p>
+                </section>
+            </section>
         </section>
     </main>
 </body>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 <link rel="stylesheet" type="text/css" href="index.css" />
 </head>
 
-<body>
+<body class="flexbox__column-direction gap40">
     <header>
         <section class="flexbox__space-between--center">
             <section class="flexbox__flex-start--center gap8">
@@ -17,7 +17,19 @@
             <p id="header__current-date" class="text__medium16 text--default"></p>
         </section>
     </header>
-    <main></main>
+    
+    <main>
+        <section class="flexbox__flex-start--center gap8">
+            <article class="current-news__box surface--alt border flexbox__flex-start--center gap16">
+                <p class="current-news__media-title text--strong">데일리뉴스</p>
+                <p class="current-news__headline text--default">[1보] 김기현·안철수·천하람·황교안, 與전대 본경선 진출진출진출</p>
+            </article>
+            <article class="current-news__box surface--alt border flexbox__flex-start--center gap16">
+                <p class="current-news__media-title text--strong">연합뉴스</p>
+                <p class="current-news__headline text--default">[1보] 김기현·안철수·천하람·황교안, 與전대 본경선 진출</p>
+            </article>
+        </section>
+    </main>
 </body>
 
 <script type="module" src="./index.js"></script>

--- a/index.js
+++ b/index.js
@@ -1,1 +1,2 @@
 import "./header/index.js"
+import "./current-news/index.js"

--- a/static/data/current-news.js
+++ b/static/data/current-news.js
@@ -1,0 +1,52 @@
+export const CURRENT_NEWS = {
+    data: [
+        {
+            media: "매일경제",
+            newsList: [
+                {
+                    title: "9명 사망 ‘시청역 사고’낸 60대 운전자…경찰 “구속영장 검토”",
+                    url: "https://www.mk.co.kr/news/society/11056649"
+                },
+                {
+                    title: "만취 상태로 시속 159㎞ 과속 운전한 50대…10대 운전자는 사망",
+                    url: "https://www.mk.co.kr/news/society/11056086"
+                },
+                {
+                    title: "“북촌 밤거리 절대 걷지 마세요”…앞으로 오후 5시 넘어 방문 땐 과태료",
+                    url: "https://www.mk.co.kr/news/politics/11055839"
+                },
+                {
+                    title: "“병원 함부로 가면 안되겠네”…오늘부터 실손보험 보험료 ‘차등제’ 시행",
+                    url: "https://www.mk.co.kr/news/economy/11055224"
+                },
+                {
+                    title: "러닝머신 타던 여성 ‘봉변’…등 뒤 열린 창문으로 떨어져 추락사",
+                    url: "https://www.mk.co.kr/news/world/11051276"
+                }
+            ],
+            length: 5
+        },
+        {
+            media: "연합뉴스",
+            newsList: [
+                {
+                    title: "학생 흉기 난동 중학교 교사들, 교장 교체 요구",
+                    url: "https://n.news.naver.com/mnews/article/001/0014783103"
+                },
+                {
+                    title: "은행 동료 넷 한꺼번에…야근 마친 31세 시청직원도 참변",
+                    url: "https://n.news.naver.com/mnews/article/001/0014782353"
+                },
+                {
+                    title: "'푸바오' 판다기지 “반려동물 동반 금지…앞으로 가방도 검사“",
+                    url: "https://n.news.naver.com/mnews/article/001/0014783060"
+                },
+                {
+                    title: "'쾅쾅' 폭탄소리 나더니 열명이 바닥에…목격자들 “급발진 아냐“",
+                    url: "https://n.news.naver.com/mnews/ranking/article/001/0014781253"
+                }
+            ],
+            length: 4
+        }
+    ]
+}

--- a/utils/format.js
+++ b/utils/format.js
@@ -1,3 +1,8 @@
+/**
+ * @description 숫자와 자리수를 받아서 자리 수에 맞게 앞에 0 패딩을 붙여주는 함수
+ * 
+ * @returns 2 -> "02"
+ */
 export function formatNumberDigit(number, digitLength) {
     return String(number).padStart(digitLength, '0')
 }

--- a/utils/getNextNumber.js
+++ b/utils/getNextNumber.js
@@ -1,0 +1,11 @@
+/**
+ * @description 주어진 숫자의 다음 숫자를 리턴하는 함수 
+ * 
+ * @returns 1 -> 2
+ */
+export function getNextNumber(number, maxNumber = Infinity) {
+    if (number + 1 < maxNumber) {
+        return number + 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## 🖥️ Preview

https://github.com/jhj2713/fe-newsstand/assets/76840145/9e2df661-0606-4fce-b594-fe0a5c7ca306

## ✔️ 구현 사항
- 최신 뉴스 영역 구현
  - rolling 애니메이션

## ❓고민했던 부분
- 애니메이션을 어떻게 처리할 것인가
  <img width="1015" alt="스크린샷 2024-07-02 오후 5 49 08" src="https://github.com/jhj2713/fe-newsstand/assets/76840145/f8ba8f38-bda1-48e6-bee8-c97cf5272a8b">

  - rolling 하면서 사라질 텍스트 DOM(1), rolling 하면서 나타날 텍스트 DOM(2) 두 개를 기준으로 rolling 애니메이션을 구현해보려고 했다.
  - 그런데 rolling 하면서 사라진 텍스트와 rolling 하면서 나타난 텍스트를 교차해줄 때 잘못하면 시점 문제로 깜빡임이 발생할 수 있을 것 같아서 이 방법보다 더 좋은 방법을 찾고 싶었다.
  
  <img width="1015" alt="스크린샷 2024-07-02 오후 5 49 08" src="https://github.com/jhj2713/fe-newsstand/assets/76840145/a6449e74-c1e9-4d96-9ac7-bd51fb59a25c">

  - 위의 1번 텍스트와 2번 텍스트를 서로 swap 할 일이 없도록 rolling 하면서 사라질 텍스트 DOM(1), 멈춰있을 때 나타날 static 텍스트 DOM(2), rolling 하면서 나타날 텍스트 DOM(3) 세 개를 기준으로 애니메이션을 구현해보았다.
  - rolling 애니메이션이 발생할 때는 static 텍스트를 잠시 숨겨뒀다가 rolling 애니메이션이 끝나면 나타나게 하는 방식으로 구현했다.


## ✏️ TODO
- 두 가지 rolling box에 시간차 두기
- rolling되는 뉴스에 hover 했을 때 UI/동작 처리