### PR TITLE
[Feat] rolling box hover 및 순차적 rolling 처리

### DIFF
--- a/current-news/index.js
+++ b/current-news/index.js
@@ -9,7 +9,7 @@ function initCurrentNews() {
         const rollingBoxDOM = newsBoxDOM.querySelector('.current-news__rolling-box');
 
         mediaTitleDOM.innerText = CURRENT_NEWS.data[idx].media;
-        rollingDOM(rollingBoxDOM, CURRENT_NEWS.data[idx])
+        rollingDOM(rollingBoxDOM, CURRENT_NEWS.data[idx], idx)
     });
 }
 

--- a/current-news/index.js
+++ b/current-news/index.js
@@ -1,5 +1,5 @@
 import { CURRENT_NEWS } from '../static/data/current-news.js'
-import { rolling } from './rolling.js';
+import { rollingDOM } from './rolling.js';
 
 function initCurrentNews() {
     const currentNewsBoxDOMs = document.querySelectorAll('.current-news__box');
@@ -9,7 +9,7 @@ function initCurrentNews() {
         const rollingBoxDOM = newsBoxDOM.querySelector('.current-news__rolling-box');
 
         mediaTitleDOM.innerText = CURRENT_NEWS.data[idx].media;
-        rolling(rollingBoxDOM, CURRENT_NEWS.data[idx])
+        rollingDOM(rollingBoxDOM, CURRENT_NEWS.data[idx])
     });
 }
 

--- a/current-news/rolling.js
+++ b/current-news/rolling.js
@@ -3,14 +3,14 @@ import { getNextNumber } from "../utils/getNextNumber.js";
 /**
  * @description 최신 뉴스 DOM의 텍스트를 rolling 해주는 함수
  */
-export function rollingDOM(rollingBoxDOM, rollingData) {
+export function rollingDOM(rollingBoxDOM, rollingData, rollingIdx) {
     const length = rollingData.length;
 
     const staticTextDOM = rollingBoxDOM.querySelector('.current-news__static-text');
     const disappearTextDOM = rollingBoxDOM.querySelector('.current-news__disappear-text');
     const appearTextDOM = rollingBoxDOM.querySelector('.current-news__appear-text');
 
-    staticTextDOM.innerText = rollingData.newsList[0].title;
+    staticTextDOM.textContent = rollingData.newsList[0].title;
     staticTextDOM.href = rollingData.newsList[0].url;
 
     if (length === 1) {
@@ -18,19 +18,23 @@ export function rollingDOM(rollingBoxDOM, rollingData) {
     }
 
     let prevIdx = 0, nextIdx = 1;
-    disappearTextDOM.innerText = rollingData.newsList[prevIdx].title;
-    appearTextDOM.innerText = rollingData.newsList[nextIdx].title;
+    disappearTextDOM.textContent = rollingData.newsList[prevIdx].title;
+    appearTextDOM.textContent = rollingData.newsList[nextIdx].title;
 
     function rolling() {
-        // rolling 애니메이션 실행
-        staticTextDOM.classList.add('current-news__not-display')
+        /**
+         * rolling 애니메이션 실행
+         */ 
+        staticTextDOM.classList.add('current-news__not-display');
         disappearTextDOM.classList.add('rolling-out');
         appearTextDOM.classList.add('rolling-in');
 
-        staticTextDOM.innerText = rollingData.newsList[nextIdx].title;
+        staticTextDOM.textContent = rollingData.newsList[nextIdx].title;
         staticTextDOM.href = rollingData.newsList[nextIdx].url;
 
-        // 다음 rolling 애니메이션을 위해 초기화
+        /**
+         * 다음 rolling 애니메이션을 위해 초기화
+         */
         prevIdx = getNextNumber(prevIdx, length);
         nextIdx = getNextNumber(nextIdx, length);
 
@@ -39,21 +43,30 @@ export function rollingDOM(rollingBoxDOM, rollingData) {
             disappearTextDOM.classList.remove('rolling-out');
             appearTextDOM.classList.remove('rolling-in');
 
-            disappearTextDOM.innerText = rollingData.newsList[prevIdx].title;
-            appearTextDOM.innerText = rollingData.newsList[nextIdx].title;        
+            disappearTextDOM.textContent = rollingData.newsList[prevIdx].title;
+            appearTextDOM.textContent = rollingData.newsList[nextIdx].title;        
         }, 1200);
     }
     
-    let intervalRolling = setInterval(rolling, 5000);
+    /**
+     * 순차적 rolling 실행
+     */
+    let intervalRolling = null;
+    setTimeout(() => {
+        intervalRolling = setInterval(rolling, 5000);
+    }, 1000 * rollingIdx);
 
+    /**
+     * static 텍스트 hover 처리
+     */
     staticTextDOM.addEventListener('mouseover', () => {
         staticTextDOM.classList.remove('text__medium14');
         staticTextDOM.classList.add('text__medium14--underline');
         clearInterval(intervalRolling);
-    })
+    });
     staticTextDOM.addEventListener('mouseout', () => {
         staticTextDOM.classList.add('text__medium14');
         staticTextDOM.classList.remove('text__medium14--underline');
         intervalRolling = setInterval(rolling, 5000);
-    })
+    });
 }

--- a/current-news/rolling.js
+++ b/current-news/rolling.js
@@ -3,7 +3,7 @@ import { getNextNumber } from "../utils/getNextNumber.js";
 /**
  * @description 최신 뉴스 DOM의 텍스트를 rolling 해주는 함수
  */
-export function rolling(rollingBoxDOM, rollingData) {
+export function rollingDOM(rollingBoxDOM, rollingData) {
     const length = rollingData.length;
 
     const staticTextDOM = rollingBoxDOM.querySelector('.current-news__static-text');
@@ -11,6 +11,7 @@ export function rolling(rollingBoxDOM, rollingData) {
     const appearTextDOM = rollingBoxDOM.querySelector('.current-news__appear-text');
 
     staticTextDOM.innerText = rollingData.newsList[0].title;
+    staticTextDOM.href = rollingData.newsList[0].url;
 
     if (length === 1) {
         return;
@@ -19,14 +20,15 @@ export function rolling(rollingBoxDOM, rollingData) {
     let prevIdx = 0, nextIdx = 1;
     disappearTextDOM.innerText = rollingData.newsList[prevIdx].title;
     appearTextDOM.innerText = rollingData.newsList[nextIdx].title;
-    
-    setInterval(() => {
+
+    function rolling() {
         // rolling 애니메이션 실행
         staticTextDOM.classList.add('current-news__not-display')
         disappearTextDOM.classList.add('rolling-out');
         appearTextDOM.classList.add('rolling-in');
 
         staticTextDOM.innerText = rollingData.newsList[nextIdx].title;
+        staticTextDOM.href = rollingData.newsList[nextIdx].url;
 
         // 다음 rolling 애니메이션을 위해 초기화
         prevIdx = getNextNumber(prevIdx, length);
@@ -40,5 +42,18 @@ export function rolling(rollingBoxDOM, rollingData) {
             disappearTextDOM.innerText = rollingData.newsList[prevIdx].title;
             appearTextDOM.innerText = rollingData.newsList[nextIdx].title;        
         }, 1200);
-    }, 5000);
+    }
+    
+    let intervalRolling = setInterval(rolling, 5000);
+
+    staticTextDOM.addEventListener('mouseover', () => {
+        staticTextDOM.classList.remove('text__medium14');
+        staticTextDOM.classList.add('text__medium14--underline');
+        clearInterval(intervalRolling);
+    })
+    staticTextDOM.addEventListener('mouseout', () => {
+        staticTextDOM.classList.add('text__medium14');
+        staticTextDOM.classList.remove('text__medium14--underline');
+        intervalRolling = setInterval(rolling, 5000);
+    })
 }

--- a/global-css/reset.css
+++ b/global-css/reset.css
@@ -10,7 +10,9 @@ body {
 p, h1, h2, h3, h4 {
     margin: 0;
     display: inline-block;
+    color: var(--gray400);
 }
 a {
     text-decoration: none;
+    color: var(--gray400);
 }

--- a/global-css/reset.css
+++ b/global-css/reset.css
@@ -11,3 +11,6 @@ p, h1, h2, h3, h4 {
     margin: 0;
     display: inline-block;
 }
+a {
+    text-decoration: none;
+}

--- a/global-css/token.css
+++ b/global-css/token.css
@@ -41,6 +41,7 @@
     font-size: 16px;
     line-height: 22px;
     text-decoration: underline;
+    cursor: pointer;
 }
 .text__medium14 {
     font-weight: 500;
@@ -50,6 +51,7 @@
     font-weight: 500;
     font-size: 14px;
     text-decoration: underline;
+    cursor: pointer;
 }
 .text__medium12 {
     font-weight: 500;

--- a/global-css/token.css
+++ b/global-css/token.css
@@ -41,7 +41,6 @@
     font-size: 16px;
     line-height: 22px;
     text-decoration: underline;
-    cursor: pointer;
 }
 .text__medium14 {
     font-weight: 500;
@@ -51,7 +50,6 @@
     font-weight: 500;
     font-size: 14px;
     text-decoration: underline;
-    cursor: pointer;
 }
 .text__medium12 {
     font-weight: 500;

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
                 <img alt="뉴스스탠드 아이콘" src="./static/icons/newspaper.svg"/>
                 <h1 class="text__bold24 text--strong">뉴스스탠드</h1>
             </section>
-            <p id="header__current-date" class="text__medium16 text--default"></p>
+            <p id="header__current-date" class="text__medium16"></p>
         </section>
     </header>
 
@@ -23,17 +23,17 @@
             <section class="current-news__box surface--alt border flexbox__flex-start--center gap16">
                 <p class="current-news__media-title text--strong text__bold14"></p>
                 <section class="current-news__rolling-box">
-                    <p class="current-news__disappear-text current-news__headline text--default text__medium14"></p>
-                    <p class="current-news__appear-text current-news__headline text--default text__medium14"></p>
-                    <a class="current-news__static-text current-news__headline text--default text__medium14" target="_blank"></a>
+                    <p class="current-news__disappear-text current-news__headline text__medium14"></p>
+                    <p class="current-news__appear-text current-news__headline text__medium14"></p>
+                    <a class="current-news__static-text current-news__headline text__medium14" target="_blank"></a>
                 </section>
             </section>
             <section class="current-news__box surface--alt border flexbox__flex-start--center gap16">
                 <p class="current-news__media-title text--strong text__bold14"></p>
                 <section class="current-news__rolling-box">
-                    <p class="current-news__disappear-text current-news__headline text--default text__medium14"></p>
-                    <p class="current-news__appear-text current-news__headline text--default text__medium14"></p>
-                    <a class="current-news__static-text current-news__headline text--default text__medium14" target="_blank"></a>
+                    <p class="current-news__disappear-text current-news__headline text__medium14"></p>
+                    <p class="current-news__appear-text current-news__headline text__medium14"></p>
+                    <a class="current-news__static-text current-news__headline text__medium14" target="_blank"></a>
                 </section>
             </section>
         </section>

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
                 <section class="current-news__rolling-box">
                     <p class="current-news__disappear-text current-news__headline text--default text__medium14"></p>
                     <p class="current-news__appear-text current-news__headline text--default text__medium14"></p>
-                    <p class="current-news__static-text current-news__headline text--default text__medium14"></p>
+                    <a class="current-news__static-text current-news__headline text--default text__medium14" target="_blank"></a>
                 </section>
             </section>
             <section class="current-news__box surface--alt border flexbox__flex-start--center gap16">
@@ -33,7 +33,7 @@
                 <section class="current-news__rolling-box">
                     <p class="current-news__disappear-text current-news__headline text--default text__medium14"></p>
                     <p class="current-news__appear-text current-news__headline text--default text__medium14"></p>
-                    <p class="current-news__static-text current-news__headline text--default text__medium14"></p>
+                    <a class="current-news__static-text current-news__headline text--default text__medium14" target="_blank"></a>
                 </section>
             </section>
         </section>


### PR DESCRIPTION
## 🖥️ Preview

https://github.com/jhj2713/fe-newsstand/assets/76840145/b95bde15-85ce-4d0d-a524-a3eb74238fba

## ✔️ 구현 사항
- 최신 뉴스 rolling box
  - hover 처리
  - box 순차적 rolling 처리


## ❓고민했던 부분
### 텍스트 삽입 방식
- innerText
  - css를 반영한 텍스트
- textContent
  - css를 반영하지 않는 텍스트
  - setter로 사용 시 innerText와 큰 차이가 없지만 굳이 css를 고려하는 기능까지는 필요 없기 때문에 textContent를 사용하기로 했다
- insertAdjacentText
  - 원하는 DOM 위치에 삽입할 수 있는 텍스트
  - insertAdjacentHTML은 이미 사용중인 요소를 다시 파싱하지 않아서 성능이 좋다고 하지만 텍스트를 삽입하는 insertAdjacentText는 innerText/textContent와 큰 차이가 없어 보인다

-> textContent로 js에서 텍스트를 삽입했다

### rolling box 순차 애니메이션 적용

- 두 개의 rolling box에 순차적으로 애니메이션이 적용되어야 했기 때문에 기존에 한꺼번에 돌아가던 rolling 로직을 수정해야했다. 왼쪽 애니메이션이 실행된 후 오른쪽 애니메이션이 1초 후 실행되면 되기 때문에 setInterval을 진입하기 전에 index 별로 setTimeout을 걸어주는 방식으로 수정했다.

```jsx
setInterval(rolling, 5000);
```

- 기존에 5초 interval로 rolling이 동작하게 만들었던 위 코드를 아래와 같이 수정했다.

```jsx
/**
 * 순차적 rolling 실행
 */
let intervalRolling = null;
setTimeout(() => {
    intervalRolling = setInterval(rolling, 5000);
}, 1000 * rollingIdx);
```

### rolling box hover 동작 처리

- rolling box 내의 헤드라인에 hover하면 헤드라인 rolling 동작이 멈추고 underline이 표시되어야한다. underline의 경우 static text의 css에 hover 가상 클래스를 사용해서 적용해주면 되는 것이지만 rolling 동작을 멈추게 하는 방식에는 고민이 많았다.
- 애니메이션이 css animation으로 구현되어있으니까 hover 됐을 때 애니메이션도 css로 멈출 수 있을까 아주 잠깐 생각해봤지만 5초 단위로 rolling을 실행해주는건 js에서 실행하고 있기 때문에 rolling을 중단시키는 동작도 js로 구현해야했다.
- css에서 hover와 같은 동작을 하는 DOM 이벤트를 찾아보았더니, 아래와 같이 찾을 수 있었다.

```jsx
/**
 * static 텍스트 hover 처리
 */
staticTextDOM.addEventListener('mouseover', () => {
    clearInterval(intervalRolling);
});
staticTextDOM.addEventListener('mouseout', () => {
    intervalRolling = setInterval(rolling, 5000);
});
```

- `mouseover`(타겟 DOM 안에 마우스가 들어오면 애니메이션이 trigger된다)가 발생하면 intervalRolling 동작을 clear해서 잠시 멈추고, `mouseout`(마우스가 타겟 DOM 안에서 밖으로 나가면 애니메이션이 trigger된다)이 발생하면 다시 intervalRolling을 등록해줘서 애니메이션이 실행되게 한다.
