### PR TITLE
[Feat] 화살표 버튼 클릭 시 이전/다음 언론사 뉴스 볼 수 있도록 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,52 +51,9 @@
             </section>
 
             <section class="media-contents__container border">
-                <ul class="media-contents__category-list flexbox__flex-start--center surface--alt text__medium14">
-                    <li class="media-contents__category-item media-contents__category-item--selected">
-                        <p class="text__bold14 text__white--default">종합/경제</p>
-                        <section>
-                            <p class="text__bold14 text__white--default">1</p> <p class="text__bold14 text__white--weak">/ 81</p>
-                        </section>
-                    </li>
-                    <li class="media-contents__category-item">
-                        <p class="text--weak">방송/통신</p>
-                    </li>
-                    <li class="media-contents__category-item">
-                        <p class="text--weak">IT</p>
-                    </li>
-                </ul>
+                <ul class="media-contents__category-list flexbox__flex-start--center surface--alt text__medium14"></ul>
 
-                <section class="media-contents__contents-box flexbox__column-direction gap16">
-                    <section class="flexbox__flex-start--center gap16">
-                        <img alt="뉴스 아이콘" src="./static/icons/list-active.svg" />
-                        <p class="text__medium12">2024.02.10 18:59 편집</p>
-                        <section class="border media-contents__subscribe-button">
-                            <img alt="구독 클릭 아이콘" src="./static/icons/plus-default.svg" />
-                            <p class="media-contents__subscribe-text text__medium12 text--weak">구독하기</p>
-                        </section>
-                        <section class="border media-contents__subscribe-button">
-                            <img alt="구독 취소 아이콘" src="./static/icons/close-default.svg" />
-                        </section>
-                    </section>
-
-                    <section class="flexbox__flex-start--start">
-                        <section class="media-contents__image-content flexbox__column-direction gap16">
-                            <img alt="뉴스 이미지" src="" style="width: 320px; height: 200px;"/>
-                            <p class="media-contents__image-headline text__medium16 text--strong">봇물처럼 터지는 공공요금 인상…꼭 지금이어야 하나봇물처럼 터지는 공공요금 인상…꼭 지금이어야 하나</p>
-                        </section>
-                        <section class="flexbox__column-direction gap16">
-                            <ul class="flexbox__column-direction gap16">
-                                <li class="media-contents__list-item">
-                                    <p class="media-contents__list-item-text text__medium16 text--bold">[단독] 美복권 키오스크 "불법"인데…정부 방치에 '우후죽순'</p>
-                                </li>
-                                <li class="media-contents__list-item">
-                                    <p class="media-contents__list-item-text text__medium16 text--bold">[단독] 美복권 키오스크 "불법"인데…정부 방치에 '우후죽순'</p>
-                                </li>
-                            </ul>
-                            <p class="media-contents__tip text__medium14 text--weak">SBS Biz 언론사에서 직접 편집한 뉴스입니다.</p>
-                        </section>
-                    </section>
-                </section>
+                <section class="media-contents__contents-box flexbox__column-direction gap16"></section>
 
                 <img class="media-contents__navigation-button media-contents__left-button" alt="이전 미디어 보기 버튼" src="./static/icons/leftbutton.svg" />
                 <img class="media-contents__navigation-button media-contents__right-button" alt="다음 미디어 보기 버튼" src="./static/icons/rightbutton.svg" />

--- a/index.js
+++ b/index.js
@@ -1,2 +1,3 @@
 import "./header/index.js"
 import "./current-news/index.js"
+import "./media-contents/index.js"

--- a/media-contents/index.css
+++ b/media-contents/index.css
@@ -17,9 +17,16 @@
     align-items: center;
     background: var(--blue100);
 }
+.media-contents__category-item-text {
+    cursor: pointer;
+}
+.media-contents__category-item-text:hover {
+    text-decoration: underline;
+}
 
 .media-contents__contents-box {
     padding: 26px 24px;
+    height: 312px;
 }
 
 .media-contents__subscribe-button {
@@ -45,6 +52,11 @@
     width: 320px;
     cursor: pointer;
 }
+.media-contents__image-content img {
+    width: 320px;
+    height: 200px;
+    object-fit: cover;
+}
 .media-contents__image-headline {
     display: -webkit-box;
     -webkit-box-orient: vertical;
@@ -52,6 +64,8 @@
     overflow: hidden;
     -webkit-line-clamp: 2;
     text-overflow: ellipsis;
+
+    word-break: keep-all;
 }
 .media-contents__image-content:hover .media-contents__image-headline {
     text-decoration: underline;
@@ -59,6 +73,11 @@
 
 .media-contents__list-item-text {
     cursor: pointer;
+
+    max-width: 532px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 }
 .media-contents__list-item:hover .media-contents__list-item-text {
     text-decoration: underline;

--- a/media-contents/index.js
+++ b/media-contents/index.js
@@ -1,0 +1,10 @@
+import { renderTotalMedia } from "./total-media.js";
+
+function initMediaContents() {
+    /**
+     * 전체 미디어 렌더링
+     */
+    renderTotalMedia();
+}
+
+initMediaContents();

--- a/media-contents/total-media.js
+++ b/media-contents/total-media.js
@@ -1,0 +1,92 @@
+import { TOTAL_MEDIA_CATEGORY } from "../static/data/total-media-category.js";
+
+/**
+ * @description 전체 언론사를 렌더링하는 함수
+ */
+export function renderTotalMedia() {
+    const category = TOTAL_MEDIA_CATEGORY.data;
+    const categoryListDOM = document.querySelector(".media-contents__category-list");
+
+    /**
+     * 미디어 카테고리 렌더링
+     * 
+     * @NOTE 기본으로 0번째 index의 카테고리가 선택된 상태
+     */
+    categoryListDOM.insertAdjacentHTML('beforeend', getSelectedCategoryItem(category[0]));
+    category.slice(1).forEach((_category) => {
+        categoryListDOM.insertAdjacentHTML('beforeend', getUnselectedCategoryItem(_category.categoryName));
+    });
+    categoryListDOM.addEventListener('click', (e) => {
+        /**
+         * TODO: category list DOM을 클릭하면 리스트 아이템으로 이벤트 위임이 되고, 해당 리스트 아이템 카테고리로 이동
+         */
+        console.log("click", e.target)
+    });
+
+    /**
+     * 선택된 카테고리의 콘텐츠 렌더링
+     */
+    const contentsBoxDOM = document.querySelector(".media-contents__contents-box");
+    const contentsString = getSelectedCategoryContents(category[0].media[0]);
+    contentsBoxDOM.insertAdjacentHTML('beforeend', contentsString);
+}
+
+/**
+ * @description 선택된 카테고리 아이템 DOM string을 반환해주는 함수 
+ * @returns "<li>...</li>"
+ */
+function getSelectedCategoryItem(category) {
+    return `<li class="media-contents__category-item media-contents__category-item--selected">
+                <p class="text__bold14 text__white--default">${category.categoryName}</p>
+                <section>
+                    <p class="text__bold14 text__white--default">1</p> <p class="text__bold14 text__white--weak">/ ${category.length}</p>
+                </section>
+            </li>`
+}
+/**
+ * @description 선택되지 않은 카테고리 아이템 DOM string을 반환해주는 함수 
+ * @returns "<li>...</li>"
+ */
+function getUnselectedCategoryItem(categoryName) {
+    return `<li class="media-contents__category-item">
+                <p class="media-contents__category-item-text text--weak">${categoryName}</p>
+            </li>`
+}
+
+function getSelectedCategoryContents(media) {
+    const { iconUrl, editDate, isSubscribed, imageContent, contents } = media;
+
+    return `
+    <section class="flexbox__flex-start--center gap16">
+        <img alt="언론사 아이콘" src="${iconUrl}" />
+        <p class="text__medium12">${editDate}</p>
+        ${isSubscribed ? `
+            <section class="border media-contents__subscribe-button">
+                <img alt="구독 취소 아이콘" src="./static/icons/close-default.svg" />
+            </section>` : `
+            <section class="border media-contents__subscribe-button">
+                <img alt="구독 클릭 아이콘" src="./static/icons/plus-default.svg" />
+                <p class="media-contents__subscribe-text text__medium12 text--weak">구독하기</p>
+            </section>`}
+    </section>
+
+    <section class="flexbox__flex-start--start gap32">
+        <a class="media-contents__image-content flexbox__column-direction gap16" href="${imageContent.url}">
+            <img alt="뉴스 이미지" src="${imageContent.imageUrl}" />
+            <p class="media-contents__image-headline text__medium16 text--strong">${imageContent.headline}</p>
+        </a>
+        <section class="flexbox__column-direction gap16">
+            <ul class="flexbox__column-direction gap16">
+                ${contents.map((content) => `
+                    <li class="media-contents__list-item">
+                        <a href="${content.url}">
+                            <p class="media-contents__list-item-text text__medium16 text--bold">${content.headline}</p>
+                        </a>
+                    </li>
+                    `)}
+            </ul>
+            <p class="media-contents__tip text__medium14 text--weak">SBS Biz 언론사에서 직접 편집한 뉴스입니다.</p>
+        </section>
+    </section>
+    `;
+}

--- a/static/data/total-media-category.js
+++ b/static/data/total-media-category.js
@@ -1,0 +1,51 @@
+export const TOTAL_MEDIA_CATEGORY = {
+    data: [
+        {
+            categoryName: "종합/경제",
+            media: [
+                {
+                    name: "한겨례",
+                    iconUrl: "https://s.pstatic.net/static/newsstand/up/2024/0219/nsd145828169.png",
+                    editDate: "07월 03일 16:23 편집",
+                    isSubscribed: false,
+                    imageContent: {
+                        imageUrl: "https://www.pressian.com/_resources/10/2024/07/03/2024070311344319469_l.jpg",
+                        url: "https://www.pressian.com/pages/articles/2024070311170206107&amp;utm_source=naver&amp;utm_medium=mynews",
+                        headline: "봇물처럼 터지는 공공요금 인상…꼭 지금이어야 하나"
+                    },
+                    contents: [
+                        {
+                            url: "",
+                            headline: "봇물처럼 터지는 공공요금 인상…꼭 지금이어야 하나"
+                        }
+                    ]
+                }
+            ],
+            length: 3
+        },
+        {
+            categoryName: "방송/통신",
+            media: [
+                {
+                    name: "세계일보",
+                    iconUrl: "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/022.png",
+                    editDate: "07월 03일 16:23 편집",
+                    isSubscribed: true,
+                    imageContent: {
+                        imageUrl: "https://it.donga.com/media/__sized__/images/2024/7/3/aafceafdecd94926-thumbnail-1920x1080-70.jpg",
+                        url: "https://it.donga.com/105568/",
+                        headline: "서울과기대, 실전 같은 '창업캠프'로 대학생 창업 경험 제공해"
+                    },
+                    contents: [
+                        {
+                            url: "",
+                            headline: "봇물처럼 터지는 공공요금 인상…꼭 지금이어야 하나"
+                        }
+                    ]
+                }
+            ],
+            length: 3
+        }
+    ],
+    length: 7
+}

--- a/static/data/total-media-category.js
+++ b/static/data/total-media-category.js
@@ -19,9 +19,26 @@ export const TOTAL_MEDIA_CATEGORY = {
                             headline: "봇물처럼 터지는 공공요금 인상…꼭 지금이어야 하나"
                         }
                     ]
+                },
+                {
+                    name: "한겨례",
+                    iconUrl: "https://s.pstatic.net/static/newsstand/up/2024/0219/nsd145828169.png",
+                    editDate: "07월 04일 16:23 편집",
+                    isSubscribed: false,
+                    imageContent: {
+                        imageUrl: "https://www.pressian.com/_resources/10/2024/07/03/2024070311344319469_l.jpg",
+                        url: "https://www.pressian.com/pages/articles/2024070311170206107&amp;utm_source=naver&amp;utm_medium=mynews",
+                        headline: "봇물처럼 터지는 공공요금 인상…꼭 지금이어야 하나"
+                    },
+                    contents: [
+                        {
+                            url: "",
+                            headline: "봇물처럼 터지는 공공요금 인상…꼭 지금이어야 하나"
+                        }
+                    ]
                 }
             ],
-            length: 3
+            length: 2
         },
         {
             categoryName: "방송/통신",
@@ -44,8 +61,8 @@ export const TOTAL_MEDIA_CATEGORY = {
                     ]
                 }
             ],
-            length: 3
+            length: 1
         }
     ],
-    length: 7
+    length: 2
 }


### PR DESCRIPTION
## 🖥️ Preview

https://github.com/jhj2713/fe-newsstand/assets/76840145/0be20696-a13a-4a85-88d5-05b35ab4cff6

## ✔️ 구현 사항
- 전체 언론사 콘텐츠
  - 데이터 매핑
  - 이전/다음 화살표 버튼 클릭 시 이전/다음 언론사 뉴스를 볼 수 있도록 구현

## ❓고민했던 부분
### 현재 언론사 페이지에서 다음 언론사 페이지로 넘어가기 위한 index를 어떻게 저장할 것인가

- 특정 언론사 페이지를 보고 있다가 이전/다음 버튼을 클릭하는 경우 해당 언론사 콘텐츠로 이동해야 한다.
- 이때 고민됐던 부분이 현재 언론사 콘텐츠가 몇 번째 데이터인지 어떻게 기억할 것인지 였다. 현재 언론사 콘텐츠 index를 기억해야 이전 콘텐츠나 다음 콘텐츠로 이동할 수 있기 때문이다.
- 처음에는 전역 상태 같은 느낌으로다가 저장할까 싶었는데 효율적으로 관리하기 어렵지 않을까 싶었다. 그래서 다른 방법을 생각해보다가 data attribute가 생각이 났다. 굳이 상태(데이터)로 가지고 있기 않고 attribute에 저장해두었다가 필요할 때 꺼내서 쓰는 방식으로 사용하면 더 간편할 것 같아서 이 방법을 사용하기로 했다.

```jsx
`<li data-selected-category-idx="${selectedCategoryIdx}" data-selected-media-idx="${selectedMediaIdx}">
    ...
</li>`
```
