### PR TITLE
[Feat] 전체 언론사 및 내가 구독한 언론사 로직 구현

### DIFF
--- a/current-news/index.css
+++ b/current-news/index.css
@@ -37,13 +37,11 @@
 }
 
 .rolling-in {
-    animation-name: rolling-in;
-    animation-duration: 1s;
+    animation: rolling-in 1s;
     animation-delay: 0.3s;
 }
 .rolling-out {
-    animation-name: rolling-out;
-    animation-duration: 1s;
+    animation: rolling-out 1s;
 }
 
 @keyframes rolling-in {

--- a/current-news/index.js
+++ b/current-news/index.js
@@ -8,7 +8,7 @@ function initCurrentNews() {
         const mediaTitleDOM = newsBoxDOM.querySelector('.current-news__media-title');
         const rollingBoxDOM = newsBoxDOM.querySelector('.current-news__rolling-box');
 
-        mediaTitleDOM.innerText = CURRENT_NEWS.data[idx].media;
+        mediaTitleDOM.textContent = CURRENT_NEWS.data[idx].media;
         rollingDOM(rollingBoxDOM, CURRENT_NEWS.data[idx], idx)
     });
 }

--- a/current-news/rolling.js
+++ b/current-news/rolling.js
@@ -28,7 +28,6 @@ export function rollingDOM(rollingBoxDOM, rollingData, rollingIdx) {
     /**
      * @description 실제 rolling 애니메이션 실행하는 함수
      */
-    let resetRollingId = null;
     function rolling() {
         staticTextDOM.classList.add('current-news__not-display');
         disappearTextDOM.classList.add('rolling-out');
@@ -43,14 +42,14 @@ export function rollingDOM(rollingBoxDOM, rollingData, rollingIdx) {
         prevIdx = getNextNumber(prevIdx, length);
         nextIdx = getNextNumber(nextIdx, length);
 
-        resetRollingId = setTimeout(() => {
+        appearTextDOM.addEventListener("animationend", () => {
             staticTextDOM.classList.remove('current-news__not-display');
             disappearTextDOM.classList.remove('rolling-out');
             appearTextDOM.classList.remove('rolling-in');
 
             disappearTextDOM.textContent = rollingData.newsList[prevIdx].title;
             appearTextDOM.textContent = rollingData.newsList[nextIdx].title;
-        }, 1200);
+        });
     }
     
     /**
@@ -66,7 +65,6 @@ export function rollingDOM(rollingBoxDOM, rollingData, rollingIdx) {
      */
     staticTextDOM.addEventListener('mouseover', () => {
         clearInterval(intervalRollingId);
-        clearTimeout(resetRollingId);
     });
     staticTextDOM.addEventListener('mouseout', () => {
         intervalRollingId = setInterval(rolling, 5000);

--- a/current-news/rolling.js
+++ b/current-news/rolling.js
@@ -5,26 +5,31 @@ import { getNextNumber } from "../utils/getNextNumber.js";
  */
 export function rollingDOM(rollingBoxDOM, rollingData, rollingIdx) {
     const length = rollingData.length;
+    
+    if (length === 0) {
+        return;
+    }
 
     const staticTextDOM = rollingBoxDOM.querySelector('.current-news__static-text');
     const disappearTextDOM = rollingBoxDOM.querySelector('.current-news__disappear-text');
     const appearTextDOM = rollingBoxDOM.querySelector('.current-news__appear-text');
 
-    staticTextDOM.textContent = rollingData.newsList[0].title;
-    staticTextDOM.href = rollingData.newsList[0].url;
+    let prevIdx = 0, nextIdx = 1;
+    staticTextDOM.textContent = rollingData.newsList[prevIdx].title;
+    staticTextDOM.href = rollingData.newsList[prevIdx].url;
 
     if (length === 1) {
         return;
     }
 
-    let prevIdx = 0, nextIdx = 1;
     disappearTextDOM.textContent = rollingData.newsList[prevIdx].title;
     appearTextDOM.textContent = rollingData.newsList[nextIdx].title;
 
+    /**
+     * @description 실제 rolling 애니메이션 실행하는 함수
+     */
+    let resetRollingId = null;
     function rolling() {
-        /**
-         * rolling 애니메이션 실행
-         */ 
         staticTextDOM.classList.add('current-news__not-display');
         disappearTextDOM.classList.add('rolling-out');
         appearTextDOM.classList.add('rolling-in');
@@ -38,31 +43,32 @@ export function rollingDOM(rollingBoxDOM, rollingData, rollingIdx) {
         prevIdx = getNextNumber(prevIdx, length);
         nextIdx = getNextNumber(nextIdx, length);
 
-        setTimeout(() => {
+        resetRollingId = setTimeout(() => {
             staticTextDOM.classList.remove('current-news__not-display');
             disappearTextDOM.classList.remove('rolling-out');
             appearTextDOM.classList.remove('rolling-in');
 
             disappearTextDOM.textContent = rollingData.newsList[prevIdx].title;
-            appearTextDOM.textContent = rollingData.newsList[nextIdx].title;        
+            appearTextDOM.textContent = rollingData.newsList[nextIdx].title;
         }, 1200);
     }
     
     /**
      * 순차적 rolling 실행
      */
-    let intervalRolling = null;
+    let intervalRollingId = null;
     setTimeout(() => {
-        intervalRolling = setInterval(rolling, 5000);
+        intervalRollingId = setInterval(rolling, 5000);
     }, 1000 * rollingIdx);
 
     /**
      * static 텍스트 hover 처리
      */
     staticTextDOM.addEventListener('mouseover', () => {
-        clearInterval(intervalRolling);
+        clearInterval(intervalRollingId);
+        clearTimeout(resetRollingId);
     });
     staticTextDOM.addEventListener('mouseout', () => {
-        intervalRolling = setInterval(rolling, 5000);
+        intervalRollingId = setInterval(rolling, 5000);
     });
 }

--- a/global-css/components.css
+++ b/global-css/components.css
@@ -3,6 +3,13 @@
     box-sizing: border-box;
 }
 
+.clickable {
+    cursor: pointer;
+}
+.clickable:hover {
+    text-decoration: underline;
+}
+
 .flexbox__space-between--center {
     display: flex;
     justify-content: space-between;

--- a/global-css/components.css
+++ b/global-css/components.css
@@ -60,6 +60,14 @@
     color: var(--gray500);
 }
 
+.snackbar__wrapper {
+    position: absolute;
+    left: 0;
+    top: 0;
+
+    width: 100vw;
+    height: 100vh;
+}
 .snackbar__container {
     position: absolute;
     left: 50%;
@@ -72,6 +80,14 @@
     box-shadow: var(--shadow);
 }
 
+.alert__wrapper {
+    position: absolute;
+    left: 0;
+    top: 0;
+
+    width: 100vw;
+    height: 100vh;
+}
 .alert__container {
     width: 320px;
 

--- a/global-css/components.css
+++ b/global-css/components.css
@@ -39,3 +39,23 @@
 .gap48 {
     gap: 48px;
 }
+
+.button {
+    border: 1px solid var(--gray100);
+    box-sizing: border-box;
+    padding: 5px 6px;
+    border-radius: 50px;
+
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1px;
+
+    cursor: pointer;
+}
+.button:hover {
+    border: 1px solid var(--gray300);
+}
+.button:hover .button__text {
+    color: var(--gray500);
+}

--- a/global-css/components.css
+++ b/global-css/components.css
@@ -40,7 +40,7 @@
     gap: 48px;
 }
 
-.button {
+.button__container {
     border: 1px solid var(--gray100);
     box-sizing: border-box;
     padding: 5px 6px;
@@ -53,9 +53,64 @@
 
     cursor: pointer;
 }
-.button:hover {
+.button__container:hover {
     border: 1px solid var(--gray300);
 }
-.button:hover .button__text {
+.button__container:hover .button__text {
     color: var(--gray500);
+}
+
+.snackbar__container {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+
+    padding: 16px 24px;
+    background-color: var(--blue500);
+
+    box-shadow: var(--shadow);
+}
+
+.alert__container {
+    width: 320px;
+
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+
+    border: 1px solid var(--gray100);
+    box-sizing: border-box;
+
+    box-shadow: var(--shadow);
+}
+.alert__contents {
+    padding: 24px;
+
+    display: flex;
+    justify-content: center;
+    text-align: center;
+
+    background-color: var(--white);
+}
+.alert__buttons {
+    height: 48px;
+    background-color: var(--gray50);
+
+    display: flex;
+    align-items: center;
+
+    border-top: 1px solid var(--gray100);
+}
+.alert__button {
+    flex: 1;
+    text-align: center;
+    cursor: pointer;
+}
+.alert__button:hover {
+    text-decoration: underline;
+}
+.alert__button--left {
+    border-right: 1px solid var(--gray100);
 }

--- a/global-css/token.css
+++ b/global-css/token.css
@@ -12,6 +12,8 @@
     --blue100: #7890E7;
     --blue500: #4362D0;
 
+    --shadow: 0px 2px 18px 0px #14212B14;
+
     font-family: "Pretendard";
 }
 

--- a/header/index.js
+++ b/header/index.js
@@ -4,7 +4,7 @@ function initHeader() {
     const currentDate = getCurrentDate();
 
     const currentDateDOM = document.querySelector('#header__current-date');
-    currentDateDOM.innerText = currentDate;
+    currentDateDOM.textContent = currentDate;
 }
 
 initHeader();

--- a/header/index.js
+++ b/header/index.js
@@ -2,8 +2,8 @@ import { getCurrentDate } from "./getCurrentDate.js";
 
 function initHeader() {
     const currentDate = getCurrentDate();
-
     const currentDateDOM = document.querySelector('#header__current-date');
+    
     currentDateDOM.textContent = currentDate;
 }
 

--- a/index.html
+++ b/index.html
@@ -41,8 +41,8 @@
         <section class="flexbox__column-direction gap24">
             <section class="flexbox__space-between--center gap24">
                 <section id="media-filter" class="flexbox__flex-start--center gap24" data-selected-filter="total-media">
-                    <h2 id="total-media" class="clickable text__bold16 text--strong">전체 언론사</h2>
-                    <h2 id="subscribed-media" class="clickable text__medium16 text--weak">내가 구독한 언론사</h2>
+                    <h2 id="total-media" class="clickable media--selected">전체 언론사</h2>
+                    <h2 id="subscribed-media" class="clickable media--unselected">내가 구독한 언론사</h2>
                 </section>
                 <section class="flexbox__flex-start--center gap8">
                     <img alt="리스트 아이콘" src="./static/icons/list-active.svg" />

--- a/index.html
+++ b/index.html
@@ -40,9 +40,9 @@
 
         <section class="flexbox__column-direction gap24">
             <section class="flexbox__space-between--center gap24">
-                <section class="flexbox__flex-start--center gap24">
-                    <h2 class="text__bold16 text--strong">전체 언론사</h2>
-                    <h2 class="text__medium16 text--weak">내가 구독한 언론사</h2>
+                <section id="media-filter" class="flexbox__flex-start--center gap24" data-selected-filter="total-media">
+                    <h2 id="total-media" class="clickable text__bold16 text--strong">전체 언론사</h2>
+                    <h2 id="subscribed-media" class="clickable text__medium16 text--weak">내가 구독한 언론사</h2>
                 </section>
                 <section class="flexbox__flex-start--center gap8">
                     <img alt="리스트 아이콘" src="./static/icons/list-active.svg" />

--- a/media-contents/filter-media.js
+++ b/media-contents/filter-media.js
@@ -1,0 +1,39 @@
+import { renderSubscribedMedia } from "./subscribed-media.js";
+import { renderTotalMedia } from "./total-media.js"
+
+/**
+ * @description 언론사 필터를 렌더하는 함수
+ */
+export function renderMediaFilter() {
+    /**
+     * @NOTE 기본값으로 전체 언론사가 보여짐
+     */
+    renderMediaContents("total-media");
+
+    const filterMediaDOM = document.querySelector("#media-filter");
+    filterMediaDOM.addEventListener("click", clickMediaFilter)
+}
+
+/**
+ * @description 언론사 필터를 클릭했을때 호출되는 함수
+ */
+function clickMediaFilter(e) {
+    const mediaId = e.target.id;
+
+    renderMediaContents(mediaId)
+}
+
+/**
+ * @description 필터에 맞는 언론사 콘텐츠를 렌더하는 함수
+ */
+function renderMediaContents(mediaId) {
+    const filterMediaDOM = document.querySelector("#media-filter");
+
+    if (mediaId === "total-media") {
+        filterMediaDOM.dataset.selectedFilter = "total-media";
+        renderTotalMedia();
+    } else if (mediaId === "subscribed-media") {
+        filterMediaDOM.dataset.selectedFilter = "subscribed-media";
+        renderSubscribedMedia();
+    }
+}

--- a/media-contents/filter-media.js
+++ b/media-contents/filter-media.js
@@ -20,7 +20,7 @@ export function renderMediaFilter() {
 function clickMediaFilter(e) {
     const mediaId = e.target.id;
 
-    renderMediaContents(mediaId)
+    renderMediaContents(mediaId);
 }
 
 /**
@@ -31,9 +31,32 @@ function renderMediaContents(mediaId) {
 
     if (mediaId === "total-media") {
         filterMediaDOM.dataset.selectedFilter = "total-media";
+        setSelectedMedia("total-media");
+        setUnselectedMedia("subscribed-media");
+
         renderTotalMedia();
     } else if (mediaId === "subscribed-media") {
         filterMediaDOM.dataset.selectedFilter = "subscribed-media";
+        setSelectedMedia("subscribed-media");
+        setUnselectedMedia("total-media");
+        
         renderSubscribedMedia();
     }
+}
+
+/**
+ * @description 선택된 언론사 카테고리에 css 부여하는 함수
+ */
+function setSelectedMedia(id) {
+    const selectedMediaDOM = document.querySelector(`#${id}`);
+    selectedMediaDOM.classList.add("media--selected");
+    selectedMediaDOM.classList.remove("media--unselected");
+}
+/**
+ * @description 선택되지 않은 언론사 카테고리에 css 부여하는 함수
+ */
+function setUnselectedMedia(id) {
+    const unselectedMediaDOM = document.querySelector(`#${id}`);
+    unselectedMediaDOM.classList.add("media--unselected");
+    unselectedMediaDOM.classList.remove("media--selected");
 }

--- a/media-contents/index.css
+++ b/media-contents/index.css
@@ -29,25 +29,6 @@
     height: 312px;
 }
 
-.media-contents__subscribe-button {
-    box-sizing: border-box;
-    padding: 5px 6px;
-    border-radius: 50px;
-
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 1px;
-
-    cursor: pointer;
-}
-.media-contents__subscribe-button:hover {
-    border: 1px solid var(--gray300);
-}
-.media-contents__subscribe-button:hover .media-contents__subscribe-text {
-    color: var(--gray500);
-}
-
 .media-contents__image-content {
     width: 320px;
     cursor: pointer;

--- a/media-contents/index.css
+++ b/media-contents/index.css
@@ -75,3 +75,17 @@
 .media-contents__right-button {
     right: -70px;
 }
+
+.media--selected {
+    font-weight: 700;
+    font-size: 16px;
+
+    color: var(--black);
+}
+.media--unselected {
+    font-weight: 500;
+    font-size: 16px;
+    line-height: 22px;
+
+    color: var(--gray200);
+}

--- a/media-contents/index.js
+++ b/media-contents/index.js
@@ -1,10 +1,10 @@
-import { renderTotalMedia } from "./total-media.js";
+import { renderMediaFilter } from "./filter-media.js";
 
 function initMediaContents() {
     /**
-     * 전체 미디어 렌더링
+     * 언론사 필터 렌더링
      */
-    renderTotalMedia();
+    renderMediaFilter();
 }
 
 initMediaContents();

--- a/media-contents/subscribed-media.js
+++ b/media-contents/subscribed-media.js
@@ -1,0 +1,11 @@
+import { TOTAL_MEDIA_CATEGORY } from "../static/data/total-media-category.js";
+
+/**
+ * @description 구독한 언론사를 렌더링하는 함수
+ */
+export function renderSubscribedMedia() {
+    const category = TOTAL_MEDIA_CATEGORY.data;
+    const categoryListDOM = document.querySelector(".media-contents__category-list");
+
+    categoryListDOM.innerHTML = "dfsfsdfs"
+}

--- a/media-contents/subscribed-media.js
+++ b/media-contents/subscribed-media.js
@@ -1,11 +1,89 @@
-import { TOTAL_MEDIA_CATEGORY } from "../static/data/total-media-category.js";
+import { CONTENTS_BY_MEDIA } from "../static/data/media.js";
+import { REMOVE_MEDIA_CATEGORY, removeTotalCategoryEvent } from "../utils/events.js";
+import { 
+    getSelectedCategoryItemDOMString, 
+    getUnselectedCategoryItemDOMString,
+    getSelectedCategoryContentsDOMString,
+    setSubscribeButtonEvent,
+} from "./util.js";
 
 /**
  * @description 구독한 언론사를 렌더링하는 함수
  */
 export function renderSubscribedMedia() {
-    const category = TOTAL_MEDIA_CATEGORY.data;
-    const categoryListDOM = document.querySelector(".media-contents__category-list");
+    renderMedia();
+}
 
-    categoryListDOM.innerHTML = "dfsfsdfs"
+function renderMedia(mediaId) {
+    const media = CONTENTS_BY_MEDIA.data;
+
+    const subscribeIdList = JSON.parse(localStorage.getItem("newsstand-subscribe") ?? "[]");
+    const subscribedMediaList = subscribeIdList.map((subscribed) => media.find((_media) => _media.id === subscribed));
+
+    const mediaListDOM = document.querySelector(".media-contents__category-list");
+    const contentsBoxDOM = document.querySelector(".media-contents__contents-box");
+
+    if (subscribedMediaList.length === 0) {
+        mediaListDOM.innerHTML = "";
+        contentsBoxDOM.innerHTML = "";
+        return;
+    }
+
+    /**
+     * 언론사 카테고리 렌더링
+     */
+    const selectedMediaId = mediaId ?? subscribeIdList[0];
+    const _selectedMediaIdx = subscribedMediaList.findIndex((media) => media.id === selectedMediaId);
+    const selectedMediaIdx = _selectedMediaIdx === -1 ? 0 : _selectedMediaIdx;
+
+    mediaListDOM.innerHTML = "";
+    subscribedMediaList.forEach((_media, _mediaIdx) => {
+        if (_mediaIdx === selectedMediaIdx) {
+            /**
+             * 선택된 카테고리인 경우
+             */
+            mediaListDOM.innerHTML += getSelectedCategoryItemDOMString(_media.name, _mediaIdx, 0);
+        } else {
+            /**
+             * 선택되지 않은 카테고리인 경우
+             */
+            mediaListDOM.innerHTML += getUnselectedCategoryItemDOMString(_media.name, _mediaIdx);
+        }
+    });
+
+    /**
+     * 카테고리 이벤트 초기화 후 이벤트 리스너 등록
+     */
+    document.addEventListener(REMOVE_MEDIA_CATEGORY, () => mediaListDOM.removeEventListener('click', clickMediaList))
+    document.dispatchEvent(removeTotalCategoryEvent);
+    mediaListDOM.addEventListener('click', clickMediaList);
+
+    /**
+     * 선택된 카테고리의 콘텐츠 렌더링
+     */
+    const contentsString = getSelectedCategoryContentsDOMString(subscribedMediaList[selectedMediaIdx]);
+    contentsBoxDOM.innerHTML = contentsString;
+
+    setSubscribeButtonEvent(subscribedMediaList[selectedMediaIdx], () => renderMedia(selectedMediaIdx, 0));
+}
+
+/**
+ * @description 언론사를 클릭했을 때 해당 언론사로 이동하는 함수
+ */
+function clickMediaList(e) {
+    /**
+     * media list DOM을 클릭하면 리스트 아이템으로 이벤트 위임이 되고, 해당 리스트 아이템 카테고리로 이동
+     */
+    const mediaIdx = parseInt(e.target.dataset.categoryIdx);
+    if (isNaN(mediaIdx)) {
+        /**
+         * 잘못된 영역을 클릭한 경우
+         */
+        return;
+    }
+
+    const subscribeIdList = JSON.parse(localStorage.getItem("newsstand-subscribe") ?? "[]");
+    const mediaId = subscribeIdList.find((_, idx) => idx === mediaIdx);
+
+    renderMedia(mediaId);
 }

--- a/media-contents/subscribed-media.js
+++ b/media-contents/subscribed-media.js
@@ -1,5 +1,10 @@
 import { CONTENTS_BY_MEDIA } from "../static/data/media.js";
-import { REMOVE_MEDIA_CATEGORY, removeTotalCategoryEvent } from "../utils/events.js";
+import { 
+    REMOVE_MEDIA_CATEGORY, 
+    REMOVE_MEDIA_ARROW,
+    removeTotalCategoryEvent,
+    removeTotalArrowEvent
+} from "../utils/events.js";
 import { 
     getSelectedCategoryItemDOMString, 
     getUnselectedCategoryItemDOMString,
@@ -11,7 +16,7 @@ import {
  * @description 구독한 언론사를 렌더링하는 함수
  */
 export function renderSubscribedMedia() {
-    renderMedia();
+    renderMedia();    
 }
 
 function renderMedia(mediaId) {
@@ -65,6 +70,22 @@ function renderMedia(mediaId) {
     contentsBoxDOM.innerHTML = contentsString;
 
     setSubscribeButtonEvent(subscribedMediaList[selectedMediaIdx], () => renderMedia(selectedMediaIdx, 0));
+
+    /**
+     * prev, next 버튼 클릭 시 언론사 이동 이벤트
+     */
+     const prevMediaButton = document.querySelector(".media-contents__left-button");
+     const nextMediaButton = document.querySelector(".media-contents__right-button");
+ 
+     function resetNavigationButton() {
+         prevMediaButton.removeEventListener("click", navigatePrevMedia);
+         nextMediaButton.removeEventListener("click", navigateNextMedia);
+     }
+     document.addEventListener(REMOVE_MEDIA_ARROW, resetNavigationButton)
+     document.dispatchEvent(removeTotalArrowEvent);
+ 
+     prevMediaButton.addEventListener("click", navigatePrevMedia);
+     nextMediaButton.addEventListener("click", navigateNextMedia);
 }
 
 /**
@@ -86,4 +107,41 @@ function clickMediaList(e) {
     const mediaId = subscribeIdList.find((_, idx) => idx === mediaIdx);
 
     renderMedia(mediaId);
+}
+
+/**
+ * @description 다음 페이지로 이동하는 함수
+ */
+function navigateNextMedia() {
+    clickNavigationButton(1);
+}
+/**
+ * @description 이전 페이지로 이동하는 함수
+ */
+function navigatePrevMedia() {
+    clickNavigationButton(-1);
+}
+
+/**
+ * @description prev, next 버튼 클릭 동작을 수행하는 함수
+ */
+function clickNavigationButton(step) {
+    const selectedCategory = document.querySelector(".media-contents__category-item--selected");
+    const selectedCategoryIdx = parseInt(selectedCategory.dataset.selectedCategoryIdx);
+
+    const subscribeIdList = JSON.parse(localStorage.getItem("newsstand-subscribe") ?? "[]");
+    
+    if (subscribeIdList.length === 0) {
+        return;
+    }
+
+    /**
+     * 이전/다음 언론사 콘텐츠로 이동
+     */
+    const nextCategoryIdx = selectedCategoryIdx + step;
+    const nextCategoryId = subscribeIdList[nextCategoryIdx];
+    if (nextCategoryIdx >= 0 && nextCategoryIdx < subscribeIdList.length) {
+        selectedCategory.dataset.selectedCategoryIdx = nextCategoryIdx;
+        renderMedia(nextCategoryId);
+    }
 }

--- a/media-contents/total-media.js
+++ b/media-contents/total-media.js
@@ -37,12 +37,7 @@ function renderMedia(categoryIdx, mediaIdx) {
         categoryListDOM.innerHTML += getUnselectedCategoryItem(_category.categoryName);
     });
 
-    categoryListDOM.addEventListener('click', (e) => {
-        /**
-         * TODO: category list DOM을 클릭하면 리스트 아이템으로 이벤트 위임이 되고, 해당 리스트 아이템 카테고리로 이동
-         */
-        console.log("click", e.target)
-    });
+    categoryListDOM.addEventListener('click', clickCategoryList);
 
     /**
      * 선택된 카테고리의 콘텐츠 렌더링
@@ -114,6 +109,13 @@ function getSelectedCategoryContents(media) {
         </section>
     </section>
     `;
+}
+
+function clickCategoryList(e) {
+    /**
+     * TODO: category list DOM을 클릭하면 리스트 아이템으로 이벤트 위임이 되고, 해당 리스트 아이템 카테고리로 이동
+     */
+    console.log("click", e.target)
 }
 
 /**

--- a/media-contents/total-media.js
+++ b/media-contents/total-media.js
@@ -51,6 +51,21 @@ function renderMedia(categoryIdx, mediaIdx) {
     const contentsBoxDOM = document.querySelector(".media-contents__contents-box");
     const contentsString = getSelectedCategoryContentsDOMString(category[categoryIdx].media[mediaIdx]);
     contentsBoxDOM.innerHTML = contentsString;
+
+    /**
+     * 구독/구독취소 이벤트 등록
+     */
+    const subscribeButtonDOM = document.querySelector('.subscribe-button--subscribe');
+    if (subscribeButtonDOM) {
+        const subscribeMediaId = parseInt(subscribeButtonDOM.dataset.mediaId);
+        subscribeButtonDOM.addEventListener("click", () => clickSubscribeButton(categoryIdx, mediaIdx, subscribeMediaId));
+    }
+
+    const unsubscribeButtonDOM = document.querySelector('.subscribe-button--unsubscribe');
+    if (unsubscribeButtonDOM) {
+        const unsubscribeMediaId = parseInt(unsubscribeButtonDOM.dataset.mediaId);
+        unsubscribeButtonDOM.addEventListener("click", () => clickUnsubscribeButton(categoryIdx, mediaIdx, unsubscribeMediaId));
+    }
 }
 
 /**
@@ -83,17 +98,20 @@ function getUnselectedCategoryItemDOMString(categoryName, categoryIdx) {
  * @returns "<section>...</section>"
  */
 function getSelectedCategoryContentsDOMString(media) {
-    const { iconUrl, editDate, isSubscribed, imageContent, contents } = media;
+    const { id, iconUrl, editDate, imageContent, contents } = media;
+
+    const subscribeList = localStorage.getItem("newsstand-subscribe") ?? [];
+    const isSubscribed = subscribeList.includes(id);
 
     return `
     <section class="flexbox__flex-start--center gap16">
-        <img alt="언론사 아이콘" src="${iconUrl}" />
+        <img alt="언론사 아이콘" src="${iconUrl}"/>
         <p class="text__medium12">${editDate}</p>
         ${isSubscribed ? `
-            <section class="button subscribe-button">
+            <section class="button__container subscribe-button--unsubscribe" data-media-id="${id}">
                 <img alt="구독 취소 아이콘" src="./static/icons/close-default.svg" />
             </section>` : `
-            <section class="button subscribe-button">
+            <section class="button__container subscribe-button--subscribe" data-media-id="${id}">
                 <img alt="구독 클릭 아이콘" src="./static/icons/plus-default.svg" />
                 <p class="button__text subscribe-button__text text__medium12 text--weak">구독하기</p>
             </section>`}
@@ -177,4 +195,25 @@ function clickNavigationButton(step) {
     const categoryIdxNumber = parseInt(selectedCategory.dataset.selectedCategoryIdx);
     const mediaIdxNumber = parseInt(selectedCategory.dataset.selectedMediaIdx);
     renderMedia(categoryIdxNumber, mediaIdxNumber);
+}
+
+/**
+ * @description 언론사 구독 이벤트 등록하는 함수
+ */
+function clickSubscribeButton(categoryIdx, mediaIdx, subscribeMediaId) {
+    const subscribeList = JSON.parse(localStorage.getItem("newsstand-subscribe") ?? "[]");
+    const newSubscribeList = JSON.stringify([...subscribeList, subscribeMediaId]);
+    localStorage.setItem("newsstand-subscribe", newSubscribeList);
+
+    renderMedia(categoryIdx, mediaIdx);
+}
+/**
+ * @description 언론사 구독 취소 이벤트 등록하는 함수
+ */
+function clickUnsubscribeButton(categoryIdx, mediaIdx, subscribeMediaId) {
+    const subscribeList = JSON.parse(localStorage.getItem("newsstand-subscribe") ?? "[]");
+    const newSubscribeList = JSON.stringify(subscribeList.filter((subscribedId) => subscribedId !== subscribeMediaId));
+    localStorage.setItem("newsstand-subscribe", newSubscribeList);
+
+    renderMedia(categoryIdx, mediaIdx);
 }

--- a/media-contents/total-media.js
+++ b/media-contents/total-media.js
@@ -205,6 +205,7 @@ function clickSubscribeButton(categoryIdx, mediaIdx, subscribeMediaId) {
     const newSubscribeList = JSON.stringify([...subscribeList, subscribeMediaId]);
     localStorage.setItem("newsstand-subscribe", newSubscribeList);
 
+    renderSnackbar("내가 구독한 언론사에 추가되었습니다.", 'subscribe');
     renderMedia(categoryIdx, mediaIdx);
 }
 /**
@@ -216,4 +217,27 @@ function clickUnsubscribeButton(categoryIdx, mediaIdx, subscribeMediaId) {
     localStorage.setItem("newsstand-subscribe", newSubscribeList);
 
     renderMedia(categoryIdx, mediaIdx);
+}
+/**
+ * @description snackbar를 렌더하는 함수
+ */
+function renderSnackbar(text, id) {
+    const bodyDOM = document.querySelector("body");
+    const snackbarDOMString = `
+    <section id="snackbar-${id}" class="snackbar__container">
+        <p class="text__medium16 text__white--default">${text}</p>
+    </section>`;
+    
+    bodyDOM.insertAdjacentHTML("beforeend", snackbarDOMString);
+
+    setTimeout(() => {
+        const snackbarDOM = bodyDOM.querySelector(`#snackbar-${id}`);
+        bodyDOM.removeChild(snackbarDOM);
+    }, 5000);
+}
+/**
+ * @description alert를 렌더하는 함수
+ */
+function renderAlert() {
+
 }

--- a/media-contents/total-media.js
+++ b/media-contents/total-media.js
@@ -1,5 +1,11 @@
-import { TOTAL_MEDIA_CATEGORY } from "../static/data/total-media-category.js";
-import { convertToMarkdown } from "../utils/convertToMarkdown.js";
+import { CONTENTS_BY_CATEGORY } from "../static/data/media.js";
+import { REMOVE_TOTAL_CATEGORY, removeMediaCategoryEvent } from "../utils/events.js";
+import { 
+    getSelectedCategoryItemDOMString, 
+    getUnselectedCategoryItemDOMString,
+    getSelectedCategoryContentsDOMString,
+    setSubscribeButtonEvent,
+} from "./util.js";
 
 /**
  * @description 전체 언론사를 렌더링하는 함수
@@ -23,7 +29,7 @@ export function renderTotalMedia() {
  * @description 미디어 카테고리, 콘텐츠를 렌더링하는 함수
  */
 function renderMedia(categoryIdx, mediaIdx) {
-    const category = TOTAL_MEDIA_CATEGORY.data;
+    const category = CONTENTS_BY_CATEGORY.data;
     const categoryListDOM = document.querySelector(".media-contents__category-list");
 
     /**
@@ -35,7 +41,7 @@ function renderMedia(categoryIdx, mediaIdx) {
             /**
              * 선택된 카테고리인 경우
              */
-            categoryListDOM.innerHTML += getSelectedCategoryItemDOMString(category[categoryIdx], categoryIdx, mediaIdx);
+            categoryListDOM.innerHTML += getSelectedCategoryItemDOMString(_category.categoryName, categoryIdx, mediaIdx, _category.length);
         } else {
             /**
              * 선택되지 않은 카테고리인 경우
@@ -44,6 +50,11 @@ function renderMedia(categoryIdx, mediaIdx) {
         }
     })
 
+    /**
+     * 카테고리 이벤트 초기화 후 이벤트 리스너 등록
+     */
+    document.addEventListener(REMOVE_TOTAL_CATEGORY, () => categoryListDOM.removeEventListener('click', clickCategoryList));
+    document.dispatchEvent(removeMediaCategoryEvent);
     categoryListDOM.addEventListener('click', clickCategoryList);
 
     /**
@@ -53,90 +64,7 @@ function renderMedia(categoryIdx, mediaIdx) {
     const contentsString = getSelectedCategoryContentsDOMString(category[categoryIdx].media[mediaIdx]);
     contentsBoxDOM.innerHTML = contentsString;
 
-    /**
-     * 구독/구독취소 이벤트 등록
-     */
-    const subscribeButtonDOM = document.querySelector('.subscribe-button--subscribe');
-    if (subscribeButtonDOM) {
-        const subscribeMediaId = parseInt(subscribeButtonDOM.dataset.mediaId);
-        subscribeButtonDOM.addEventListener("click", () => clickSubscribeButton(categoryIdx, mediaIdx, subscribeMediaId));
-    }
-
-    const unsubscribeButtonDOM = document.querySelector('.subscribe-button--unsubscribe');
-    if (unsubscribeButtonDOM) {
-        const unsubscribeMediaId = parseInt(unsubscribeButtonDOM.dataset.mediaId);
-        unsubscribeButtonDOM.addEventListener("click", () => clickUnsubscribeButton(categoryIdx, mediaIdx, unsubscribeMediaId));
-    }
-}
-
-/**
- * @description 선택된 카테고리 아이템 DOM string을 반환해주는 함수
- * 
- * @returns "<li>...</li>"
- */
-function getSelectedCategoryItemDOMString(category, selectedCategoryIdx, selectedMediaIdx) {
-    return `<li class="media-contents__category-item media-contents__category-item--selected" data-selected-category-idx="${selectedCategoryIdx}" data-selected-media-idx="${selectedMediaIdx}">
-                <p class="text__bold14 text__white--default">${category.categoryName}</p>
-                <section>
-                    <p class="text__bold14 text__white--default">${selectedMediaIdx + 1}</p> <p class="text__bold14 text__white--weak">/ ${category.length}</p>
-                </section>
-            </li>`
-}
-/**
- * @description 선택되지 않은 카테고리 아이템 DOM string을 반환해주는 함수 
- * 
- * @returns "<li>...</li>"
- */
-function getUnselectedCategoryItemDOMString(categoryName, categoryIdx) {
-    return `<li class="media-contents__category-item">
-                <p class="media-contents__category-item-text text--weak" data-category-idx="${categoryIdx}">${categoryName}</p>
-            </li>`
-}
-
-/**
- * @description 선택된 카테고리의 콘텐츠 DOM string을 반환해주는 함수
- * 
- * @returns "<section>...</section>"
- */
-function getSelectedCategoryContentsDOMString(media) {
-    const { id, iconUrl, editDate, imageContent, contents } = media;
-
-    const subscribeList = localStorage.getItem("newsstand-subscribe") ?? [];
-    const isSubscribed = subscribeList.includes(id);
-
-    return `
-    <section class="flexbox__flex-start--center gap16">
-        <img alt="언론사 아이콘" src="${iconUrl}"/>
-        <p class="text__medium12">${editDate}</p>
-        ${isSubscribed ? `
-            <section class="button__container subscribe-button--unsubscribe" data-media-id="${id}">
-                <img alt="구독 취소 아이콘" src="./static/icons/close-default.svg" />
-            </section>` : `
-            <section class="button__container subscribe-button--subscribe" data-media-id="${id}">
-                <img alt="구독 클릭 아이콘" src="./static/icons/plus-default.svg" />
-                <p class="button__text subscribe-button__text text__medium12 text--weak">구독하기</p>
-            </section>`}
-    </section>
-
-    <section class="flexbox__flex-start--start gap32">
-        <a class="media-contents__image-content flexbox__column-direction gap16" href="${imageContent.url}" target="_blank">
-            <img alt="뉴스 이미지" src="${imageContent.imageUrl}" />
-            <p class="media-contents__image-headline text__medium16 text--strong">${imageContent.headline}</p>
-        </a>
-        <section class="flexbox__column-direction gap16">
-            <ul class="flexbox__column-direction gap16">
-                ${contents.map((content) => `
-                    <li class="media-contents__list-item">
-                        <a href="${content.url}">
-                            <p class="media-contents__list-item-text text__medium16 text--bold">${content.headline}</p>
-                        </a>
-                    </li>
-                    `)}
-            </ul>
-            <p class="media-contents__tip text__medium14 text--weak">SBS Biz 언론사에서 직접 편집한 뉴스입니다.</p>
-        </section>
-    </section>
-    `;
+    setSubscribeButtonEvent(CONTENTS_BY_CATEGORY.data[categoryIdx].media[mediaIdx], () => renderMedia(categoryIdx, mediaIdx));
 }
 
 /**
@@ -166,7 +94,7 @@ function clickNavigationButton(step) {
     const selectedCategoryIdx = parseInt(selectedCategory.dataset.selectedCategoryIdx);
     const selectedMediaIdx = parseInt(selectedCategory.dataset.selectedMediaIdx);
 
-    const category = TOTAL_MEDIA_CATEGORY.data;
+    const category = CONTENTS_BY_CATEGORY.data;
     const currentCategory = category[selectedCategoryIdx];
 
     /**
@@ -185,7 +113,7 @@ function clickNavigationButton(step) {
         selectedCategory.dataset.selectedMediaIdx = category[prevCategoryIdx].length - 1;
     } else if (nextMediaIdx === currentCategory.length) {
         const nextCategoryIdx = selectedCategoryIdx + 1;
-        if (nextCategoryIdx === TOTAL_MEDIA_CATEGORY.length) {
+        if (nextCategoryIdx === CONTENTS_BY_CATEGORY.length) {
             return;
         }
         
@@ -196,126 +124,4 @@ function clickNavigationButton(step) {
     const categoryIdxNumber = parseInt(selectedCategory.dataset.selectedCategoryIdx);
     const mediaIdxNumber = parseInt(selectedCategory.dataset.selectedMediaIdx);
     renderMedia(categoryIdxNumber, mediaIdxNumber);
-}
-
-/**
- * @description 언론사 구독 이벤트 등록하는 함수
- */
-function clickSubscribeButton(categoryIdx, mediaIdx, subscribeMediaId) {
-    const subscribeList = JSON.parse(localStorage.getItem("newsstand-subscribe") ?? "[]");
-    const newSubscribeList = JSON.stringify([...subscribeList, subscribeMediaId]);
-    localStorage.setItem("newsstand-subscribe", newSubscribeList);
-
-    renderSnackbar("내가 구독한 언론사에 추가되었습니다.", 'subscribe');
-    renderMedia(categoryIdx, mediaIdx);
-}
-/**
- * @description 언론사 구독 취소 이벤트 등록하는 함수
- */
-function clickUnsubscribeButton(categoryIdx, mediaIdx, subscribeMediaId) {
-    const media = TOTAL_MEDIA_CATEGORY.data[categoryIdx].media[mediaIdx];
-    const mediaName = media.name;
-    const id = media.id;
-
-    function clickCancel() {
-        const bodyDOM = document.querySelector("body");
-        const alertDOM = bodyDOM.querySelector(`#alert-${id}`);
-        bodyDOM.removeChild(alertDOM);
-    }
-    function clickUnsubscribe() {
-        const subscribeList = JSON.parse(localStorage.getItem("newsstand-subscribe") ?? "[]");
-        const newSubscribeList = JSON.stringify(subscribeList.filter((subscribedId) => subscribedId !== subscribeMediaId));
-        localStorage.setItem("newsstand-subscribe", newSubscribeList);
-
-        clickCancel();
-        renderMedia(categoryIdx, mediaIdx);
-    }
-
-    renderAlert(`{${mediaName}}을(를)\n구독해지하시겠습니까?`, id, "예, 해지합니다", "아니오", clickUnsubscribe, clickCancel, clickCancel)
-    renderMedia(categoryIdx, mediaIdx);
-}
-/**
- * @description snackbar를 렌더하는 함수
- */
-function renderSnackbar(text, id) {
-    const bodyDOM = document.querySelector("body");
-    const snackbarDOMString = `
-    <section id="snackbar-${id}" class="snackbar__wrapper">
-        <section class="snackbar__container">
-            <p class="text__medium16 text__white--default">${text}</p>
-        </section>
-    </section>`;
-    
-    bodyDOM.insertAdjacentHTML("beforeend", snackbarDOMString);
-
-    /**
-     * 5초 후 snackbar 삭제 로직
-     */
-    let snackbarId = null;
-    const snackbarWrapperDOM = document.querySelector(`#snackbar-${id}`);
-    snackbarId = setTimeout(() => {
-        bodyDOM.removeChild(snackbarWrapperDOM);
-        snackbarId = null;
-    }, 5000);
-
-    /**
-     * snackbar 외부 영역 클릭 시 snackbar 삭제 로직
-     */
-    snackbarWrapperDOM.addEventListener("click", clickSnackbarOutside);
-    function clickSnackbarOutside(e) {
-        if (e.target !== snackbarWrapperDOM) {
-            return;
-        }
-
-        if (snackbarId !== null) {
-            clearTimeout(snackbarId);
-            snackbarId = null;
-        }
-
-        const bodyDOM = document.querySelector("body");
-        bodyDOM.removeChild(snackbarWrapperDOM);
-    }
-}
-/**
- * @description alert를 렌더하는 함수
- */
-function renderAlert(text, id, leftButtonText, rightButtonText, leftButtonEventHandler, rightButtonEventHandler) {
-    const markdownText = convertToMarkdown(text, 16);
-
-    const bodyDOM = document.querySelector("body");
-    const alertDOMString = `
-    <section id="alert-${id}" class="alert__wrapper">
-        <section class="alert__container">
-            <section class="alert__contents">${markdownText}</section>
-        
-            <section class="alert__buttons">
-                <p class="alert__button alert__button--left text__medium16">${leftButtonText}</p>
-                <p class="alert__button alert__button--right text__medium16 text--strong">${rightButtonText}</p>
-            </section>
-        </section>
-    </section>`;
-
-    bodyDOM.insertAdjacentHTML("beforeend", alertDOMString);
-
-    /**
-     * alert 이벤트 리스너 부착
-     */
-    const leftButtonDOM = document.querySelector(".alert__button--left");
-    const rightButtonDOM = document.querySelector(".alert__button--right");
-    leftButtonDOM.addEventListener("click", leftButtonEventHandler);
-    rightButtonDOM.addEventListener("click", rightButtonEventHandler);
-
-    /**
-     * alert 외부 영역 클릭 시 alert 삭제 로직
-     */
-    const alertWrapperDOM = document.querySelector(`#alert-${id}`);
-    alertWrapperDOM.addEventListener("click", clickAlertOutside);
-    function clickAlertOutside(e) {
-        if (e.target !== alertWrapperDOM) {
-            return;
-        }
-
-        const bodyDOM = document.querySelector("body");
-        bodyDOM.removeChild(alertWrapperDOM);
-    }
 }

--- a/media-contents/total-media.js
+++ b/media-contents/total-media.js
@@ -90,12 +90,12 @@ function getSelectedCategoryContentsDOMString(media) {
         <img alt="언론사 아이콘" src="${iconUrl}" />
         <p class="text__medium12">${editDate}</p>
         ${isSubscribed ? `
-            <section class="border media-contents__subscribe-button">
+            <section class="button subscribe-button">
                 <img alt="구독 취소 아이콘" src="./static/icons/close-default.svg" />
             </section>` : `
-            <section class="border media-contents__subscribe-button">
+            <section class="button subscribe-button">
                 <img alt="구독 클릭 아이콘" src="./static/icons/plus-default.svg" />
-                <p class="media-contents__subscribe-text text__medium12 text--weak">구독하기</p>
+                <p class="button__text subscribe-button__text text__medium12 text--weak">구독하기</p>
             </section>`}
     </section>
 
@@ -134,7 +134,7 @@ function clickCategoryList(e) {
          */
         return;
     }
-    
+
     renderMedia(categoryIdx, 0);
 }
 

--- a/media-contents/total-media.js
+++ b/media-contents/total-media.js
@@ -1,5 +1,10 @@
 import { CONTENTS_BY_CATEGORY } from "../static/data/media.js";
-import { REMOVE_TOTAL_CATEGORY, removeMediaCategoryEvent } from "../utils/events.js";
+import { 
+    REMOVE_TOTAL_ARROW, 
+    REMOVE_TOTAL_CATEGORY, 
+    removeMediaCategoryEvent,
+    removeMediaArrowEvent
+} from "../utils/events.js";
 import { 
     getSelectedCategoryItemDOMString, 
     getUnselectedCategoryItemDOMString,
@@ -14,15 +19,7 @@ export function renderTotalMedia() {
     /**
      * @NOTE 기본으로 0번째 index의 카테고리, 미디어가 선택된 상태
      */
-    renderMedia(0, 0);
-
-    /**
-     * prev, next 버튼 클릭 시 언론사 이동 이벤트
-     */
-    const prevMediaButton = document.querySelector(".media-contents__left-button");
-    const nextMediaButton = document.querySelector(".media-contents__right-button");
-    prevMediaButton.addEventListener("click", () => clickNavigationButton(-1));
-    nextMediaButton.addEventListener("click", () => clickNavigationButton(1));
+    renderMedia(0, 0)
 }
 
 /**
@@ -65,6 +62,22 @@ function renderMedia(categoryIdx, mediaIdx) {
     contentsBoxDOM.innerHTML = contentsString;
 
     setSubscribeButtonEvent(CONTENTS_BY_CATEGORY.data[categoryIdx].media[mediaIdx], () => renderMedia(categoryIdx, mediaIdx));
+
+    /**
+     * prev, next 버튼 클릭 시 언론사 이동 이벤트
+     */
+    const prevMediaButton = document.querySelector(".media-contents__left-button");
+    const nextMediaButton = document.querySelector(".media-contents__right-button");
+
+    function resetNavigationButton() {
+        prevMediaButton.removeEventListener("click", navigatePrevMedia);
+        nextMediaButton.removeEventListener("click", navigateNextMedia);
+    }
+    document.addEventListener(REMOVE_TOTAL_ARROW, resetNavigationButton)
+    document.dispatchEvent(removeMediaArrowEvent);
+
+    prevMediaButton.addEventListener("click", navigatePrevMedia);
+    nextMediaButton.addEventListener("click", navigateNextMedia);
 }
 
 /**
@@ -83,6 +96,19 @@ function clickCategoryList(e) {
     }
 
     renderMedia(categoryIdx, 0);
+}
+
+/**
+ * @description 다음 페이지로 이동하는 함수
+ */
+function navigateNextMedia() {
+    clickNavigationButton(1);
+}
+/**
+ * @description 이전 페이지로 이동하는 함수
+ */
+function navigatePrevMedia() {
+    clickNavigationButton(-1);
 }
 
 /**

--- a/media-contents/total-media.js
+++ b/media-contents/total-media.js
@@ -29,13 +29,19 @@ function renderMedia(categoryIdx, mediaIdx) {
      * 미디어 카테고리 렌더링
      */
     categoryListDOM.innerHTML = '';
-    category.slice(0, categoryIdx).map((_category) => {
-        categoryListDOM.innerHTML += getUnselectedCategoryItem(_category.categoryName);
+    category.forEach((_category, _categoryIdx) => {
+        if (_categoryIdx === categoryIdx) {
+            /**
+             * 선택된 카테고리인 경우
+             */
+            categoryListDOM.innerHTML += getSelectedCategoryItemDOMString(category[categoryIdx], categoryIdx, mediaIdx);
+        } else {
+            /**
+             * 선택되지 않은 카테고리인 경우
+             */
+            categoryListDOM.innerHTML += getUnselectedCategoryItemDOMString(_category.categoryName, _categoryIdx);
+        }
     })
-    categoryListDOM.innerHTML += getSelectedCategoryItem(category[categoryIdx], categoryIdx, mediaIdx);
-    category.slice(categoryIdx + 1).forEach((_category) => {
-        categoryListDOM.innerHTML += getUnselectedCategoryItem(_category.categoryName);
-    });
 
     categoryListDOM.addEventListener('click', clickCategoryList);
 
@@ -43,15 +49,16 @@ function renderMedia(categoryIdx, mediaIdx) {
      * 선택된 카테고리의 콘텐츠 렌더링
      */
     const contentsBoxDOM = document.querySelector(".media-contents__contents-box");
-    const contentsString = getSelectedCategoryContents(category[categoryIdx].media[mediaIdx]);
+    const contentsString = getSelectedCategoryContentsDOMString(category[categoryIdx].media[mediaIdx]);
     contentsBoxDOM.innerHTML = contentsString;
 }
 
 /**
  * @description 선택된 카테고리 아이템 DOM string을 반환해주는 함수
+ * 
  * @returns "<li>...</li>"
  */
-function getSelectedCategoryItem(category, selectedCategoryIdx, selectedMediaIdx) {
+function getSelectedCategoryItemDOMString(category, selectedCategoryIdx, selectedMediaIdx) {
     return `<li class="media-contents__category-item media-contents__category-item--selected" data-selected-category-idx="${selectedCategoryIdx}" data-selected-media-idx="${selectedMediaIdx}">
                 <p class="text__bold14 text__white--default">${category.categoryName}</p>
                 <section>
@@ -61,19 +68,21 @@ function getSelectedCategoryItem(category, selectedCategoryIdx, selectedMediaIdx
 }
 /**
  * @description 선택되지 않은 카테고리 아이템 DOM string을 반환해주는 함수 
+ * 
  * @returns "<li>...</li>"
  */
-function getUnselectedCategoryItem(categoryName) {
+function getUnselectedCategoryItemDOMString(categoryName, categoryIdx) {
     return `<li class="media-contents__category-item">
-                <p class="media-contents__category-item-text text--weak">${categoryName}</p>
+                <p class="media-contents__category-item-text text--weak" data-category-idx="${categoryIdx}">${categoryName}</p>
             </li>`
 }
 
 /**
  * @description 선택된 카테고리의 콘텐츠 DOM string을 반환해주는 함수
+ * 
  * @returns "<section>...</section>"
  */
-function getSelectedCategoryContents(media) {
+function getSelectedCategoryContentsDOMString(media) {
     const { iconUrl, editDate, isSubscribed, imageContent, contents } = media;
 
     return `
@@ -91,7 +100,7 @@ function getSelectedCategoryContents(media) {
     </section>
 
     <section class="flexbox__flex-start--start gap32">
-        <a class="media-contents__image-content flexbox__column-direction gap16" href="${imageContent.url}">
+        <a class="media-contents__image-content flexbox__column-direction gap16" href="${imageContent.url}" target="_blank">
             <img alt="뉴스 이미지" src="${imageContent.imageUrl}" />
             <p class="media-contents__image-headline text__medium16 text--strong">${imageContent.headline}</p>
         </a>
@@ -111,11 +120,22 @@ function getSelectedCategoryContents(media) {
     `;
 }
 
+/**
+ * @description 카테고리를 클릭했을 때 해당 카테고리로 이동하는 함수
+ */
 function clickCategoryList(e) {
     /**
-     * TODO: category list DOM을 클릭하면 리스트 아이템으로 이벤트 위임이 되고, 해당 리스트 아이템 카테고리로 이동
+     * category list DOM을 클릭하면 리스트 아이템으로 이벤트 위임이 되고, 해당 리스트 아이템 카테고리로 이동
      */
-    console.log("click", e.target)
+    const categoryIdx = parseInt(e.target.dataset.categoryIdx);
+    if (isNaN(categoryIdx)) {
+        /**
+         * 잘못된 영역을 클릭한 경우
+         */
+        return;
+    }
+    
+    renderMedia(categoryIdx, 0);
 }
 
 /**
@@ -130,6 +150,9 @@ function clickNavigationButton(step) {
     const category = TOTAL_MEDIA_CATEGORY.data;
     const currentCategory = category[selectedCategoryIdx];
 
+    /**
+     * 이전/다음 언론사 콘텐츠로 이동
+     */
     const nextMediaIdx = selectedMediaIdx + step;
     if (nextMediaIdx >= 0 && nextMediaIdx < currentCategory.length) {
         selectedCategory.dataset.selectedMediaIdx = nextMediaIdx;
@@ -138,6 +161,7 @@ function clickNavigationButton(step) {
         if (prevCategoryIdx < 0) {
             return;
         }
+
         selectedCategory.dataset.selectedCategoryIdx = prevCategoryIdx;
         selectedCategory.dataset.selectedMediaIdx = category[prevCategoryIdx].length - 1;
     } else if (nextMediaIdx === currentCategory.length) {
@@ -145,6 +169,7 @@ function clickNavigationButton(step) {
         if (nextCategoryIdx === TOTAL_MEDIA_CATEGORY.length) {
             return;
         }
+        
         selectedCategory.dataset.selectedCategoryIdx = nextCategoryIdx;
         selectedCategory.dataset.selectedMediaIdx = 0;
     }

--- a/media-contents/util.js
+++ b/media-contents/util.js
@@ -1,0 +1,218 @@
+import { convertToMarkdown } from "../utils/convertToMarkdown.js";
+
+/**
+ * @description 선택된 카테고리 아이템 DOM string을 반환해주는 함수
+ * 
+ * @returns "<li>...</li>"
+ */
+export function getSelectedCategoryItemDOMString(categoryName, selectedCategoryIdx, selectedMediaIdx, categoryLength) {
+    /**
+     * category length가 존재하는 경우 : 전체 언론사
+     * category length가 존재하지 않는 경우 : 내가 구독한 언론사
+     */
+    return `<li class="media-contents__category-item media-contents__category-item--selected" data-selected-category-idx="${selectedCategoryIdx}" data-selected-media-idx="${selectedMediaIdx}">
+                <p class="text__bold14 text__white--default">${categoryName}</p>
+                <section>
+                    ${categoryLength ? `
+                        <p class="text__bold14 text__white--default">${selectedMediaIdx + 1}</p> <p class="text__bold14 text__white--weak">/ ${categoryLength}</p>
+                        ` : `
+                        <img alt="화살표" src="./static/icons/arrow-right.svg" />
+                    `}
+                </section>
+            </li>`
+}
+/**
+ * @description 선택되지 않은 카테고리 아이템 DOM string을 반환해주는 함수 
+ * 
+ * @returns "<li>...</li>"
+ */
+export function getUnselectedCategoryItemDOMString(categoryName, categoryIdx) {
+    return `<li class="media-contents__category-item">
+                <p class="media-contents__category-item-text text--weak" data-category-idx="${categoryIdx}">${categoryName}</p>
+            </li>`
+}
+
+/**
+ * @description 선택된 카테고리의 콘텐츠 DOM string을 반환해주는 함수
+ * 
+ * @returns "<section>...</section>"
+ */
+export function getSelectedCategoryContentsDOMString(media) {
+    const { id, iconUrl, editDate, imageContent, contents } = media;
+
+    const subscribeList = localStorage.getItem("newsstand-subscribe") ?? [];
+    const isSubscribed = subscribeList.includes(id);
+
+    return `
+    <section class="flexbox__flex-start--center gap16">
+        <img alt="언론사 아이콘" src="${iconUrl}"/>
+        <p class="text__medium12">${editDate}</p>
+        ${isSubscribed ? `
+            <section class="button__container subscribe-button--unsubscribe" data-media-id="${id}">
+                <img alt="구독 취소 아이콘" src="./static/icons/close-default.svg" />
+            </section>` : `
+            <section class="button__container subscribe-button--subscribe" data-media-id="${id}">
+                <img alt="구독 클릭 아이콘" src="./static/icons/plus-default.svg" />
+                <p class="button__text subscribe-button__text text__medium12 text--weak">구독하기</p>
+            </section>`}
+    </section>
+
+    <section class="flexbox__flex-start--start gap32">
+        <a class="media-contents__image-content flexbox__column-direction gap16" href="${imageContent.url}" target="_blank">
+            <img alt="뉴스 이미지" src="${imageContent.imageUrl}" />
+            <p class="media-contents__image-headline text__medium16 text--strong">${imageContent.headline}</p>
+        </a>
+        <section class="flexbox__column-direction gap16">
+            <ul class="flexbox__column-direction gap16">
+                ${contents.map((content) => `
+                    <li class="media-contents__list-item">
+                        <a href="${content.url}">
+                            <p class="media-contents__list-item-text text__medium16 text--bold">${content.headline}</p>
+                        </a>
+                    </li>
+                    `)}
+            </ul>
+            <p class="media-contents__tip text__medium14 text--weak">SBS Biz 언론사에서 직접 편집한 뉴스입니다.</p>
+        </section>
+    </section>
+    `;
+}
+
+/**
+ * @description 구독/구독취소 이벤트 등록하는 함수
+ */
+export function setSubscribeButtonEvent(media, triggerRender) {  
+    const subscribeButtonDOM = document.querySelector('.subscribe-button--subscribe');
+    if (subscribeButtonDOM) {
+        const subscribeMediaId = parseInt(subscribeButtonDOM.dataset.mediaId);
+        subscribeButtonDOM.addEventListener("click", () => clickSubscribeButton(subscribeMediaId, triggerRender));
+    }
+
+    const unsubscribeButtonDOM = document.querySelector('.subscribe-button--unsubscribe');
+    if (unsubscribeButtonDOM) {
+        const unsubscribeMediaId = parseInt(unsubscribeButtonDOM.dataset.mediaId);
+        unsubscribeButtonDOM.addEventListener("click", () => clickUnsubscribeButton(media, unsubscribeMediaId, triggerRender));
+    }
+}
+
+/**
+ * @description 언론사 구독 이벤트 등록하는 함수
+ */
+function clickSubscribeButton(subscribeMediaId, triggerRender) {
+    const subscribeList = JSON.parse(localStorage.getItem("newsstand-subscribe") ?? "[]");
+    const newSubscribeList = JSON.stringify([...subscribeList, subscribeMediaId]);
+    localStorage.setItem("newsstand-subscribe", newSubscribeList);
+
+    renderSnackbar("내가 구독한 언론사에 추가되었습니다.", 'subscribe');
+    triggerRender();
+}
+/**
+ * @description 언론사 구독 취소 이벤트 등록하는 함수
+ */
+function clickUnsubscribeButton(media, subscribeMediaId, triggerRender) {
+    const mediaName = media.name;
+    const id = media.id;
+
+    function clickCancel() {
+        const bodyDOM = document.querySelector("body");
+        const alertDOM = bodyDOM.querySelector(`#alert-${id}`);
+        bodyDOM.removeChild(alertDOM);
+    }
+    function clickUnsubscribe() {
+        const subscribeList = JSON.parse(localStorage.getItem("newsstand-subscribe") ?? "[]");
+        const newSubscribeList = JSON.stringify(subscribeList.filter((subscribedId) => subscribedId !== subscribeMediaId));
+        localStorage.setItem("newsstand-subscribe", newSubscribeList);
+
+        clickCancel();
+        triggerRender();
+    }
+
+    renderAlert(`{${mediaName}}을(를)\n구독해지하시겠습니까?`, id, "예, 해지합니다", "아니오", clickUnsubscribe, clickCancel, clickCancel)
+}
+
+/**
+ * @description alert를 렌더하는 함수
+ */
+export function renderAlert(text, id, leftButtonText, rightButtonText, leftButtonEventHandler, rightButtonEventHandler) {
+    const markdownText = convertToMarkdown(text, 16);
+
+    const bodyDOM = document.querySelector("body");
+    const alertDOMString = `
+    <section id="alert-${id}" class="alert__wrapper">
+        <section class="alert__container">
+            <section class="alert__contents">${markdownText}</section>
+        
+            <section class="alert__buttons">
+                <p class="alert__button alert__button--left text__medium16">${leftButtonText}</p>
+                <p class="alert__button alert__button--right text__medium16 text--strong">${rightButtonText}</p>
+            </section>
+        </section>
+    </section>`;
+
+    bodyDOM.insertAdjacentHTML("beforeend", alertDOMString);
+
+    /**
+     * alert 이벤트 리스너 부착
+     */
+    const leftButtonDOM = document.querySelector(".alert__button--left");
+    const rightButtonDOM = document.querySelector(".alert__button--right");
+    leftButtonDOM.addEventListener("click", leftButtonEventHandler);
+    rightButtonDOM.addEventListener("click", rightButtonEventHandler);
+
+    /**
+     * alert 외부 영역 클릭 시 alert 삭제 로직
+     */
+    const alertWrapperDOM = document.querySelector(`#alert-${id}`);
+    alertWrapperDOM.addEventListener("click", clickAlertOutside);
+    function clickAlertOutside(e) {
+        if (e.target !== alertWrapperDOM) {
+            return;
+        }
+
+        const bodyDOM = document.querySelector("body");
+        bodyDOM.removeChild(alertWrapperDOM);
+    }
+}
+
+/**
+ * @description snackbar를 렌더하는 함수
+ */
+function renderSnackbar(text, id) {
+    const bodyDOM = document.querySelector("body");
+    const snackbarDOMString = `
+    <section id="snackbar-${id}" class="snackbar__wrapper">
+        <section class="snackbar__container">
+            <p class="text__medium16 text__white--default">${text}</p>
+        </section>
+    </section>`;
+    
+    bodyDOM.insertAdjacentHTML("beforeend", snackbarDOMString);
+
+    /**
+     * 5초 후 snackbar 삭제 로직
+     */
+    let snackbarId = null;
+    const snackbarWrapperDOM = document.querySelector(`#snackbar-${id}`);
+    snackbarId = setTimeout(() => {
+        bodyDOM.removeChild(snackbarWrapperDOM);
+        snackbarId = null;
+    }, 5000);
+
+    /**
+     * snackbar 외부 영역 클릭 시 snackbar 삭제 로직
+     */
+    snackbarWrapperDOM.addEventListener("click", clickSnackbarOutside);
+    function clickSnackbarOutside(e) {
+        if (e.target !== snackbarWrapperDOM) {
+            return;
+        }
+
+        if (snackbarId !== null) {
+            clearTimeout(snackbarId);
+            snackbarId = null;
+        }
+
+        const bodyDOM = document.querySelector("body");
+        bodyDOM.removeChild(snackbarWrapperDOM);
+    }
+}

--- a/static/data/media.js
+++ b/static/data/media.js
@@ -1,4 +1,4 @@
-export const TOTAL_MEDIA_CATEGORY = {
+export const CONTENTS_BY_CATEGORY = {
     data: [
         {
             categoryName: "종합/경제",
@@ -65,4 +65,44 @@ export const TOTAL_MEDIA_CATEGORY = {
         }
     ],
     length: 2
+}
+
+export const CONTENTS_BY_MEDIA = {
+    data: [
+        {
+            id: 0,
+            name: "한겨례",
+            iconUrl: "https://s.pstatic.net/static/newsstand/up/2024/0219/nsd145828169.png",
+            editDate: "07월 03일 16:23 편집",
+            imageContent: {
+                imageUrl: "https://www.pressian.com/_resources/10/2024/07/03/2024070311344319469_l.jpg",
+                url: "https://www.pressian.com/pages/articles/2024070311170206107&amp;utm_source=naver&amp;utm_medium=mynews",
+                headline: "봇물처럼 터지는 공공요금 인상…꼭 지금이어야 하나"
+            },
+            contents: [
+                {
+                    url: "",
+                    headline: "봇물처럼 터지는 공공요금 인상…꼭 지금이어야 하나"
+                }
+            ]
+        },
+        {
+            id: 1,
+            name: "세계일보",
+            iconUrl: "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/022.png",
+            editDate: "07월 03일 16:23 편집",
+            imageContent: {
+                imageUrl: "https://it.donga.com/media/__sized__/images/2024/7/3/aafceafdecd94926-thumbnail-1920x1080-70.jpg",
+                url: "https://it.donga.com/105568/",
+                headline: "서울과기대, 실전 같은 '창업캠프'로 대학생 창업 경험 제공해"
+            },
+            contents: [
+                {
+                    url: "",
+                    headline: "봇물처럼 터지는 공공요금 인상…꼭 지금이어야 하나"
+                }
+            ]
+        }
+    ],
+
 }

--- a/static/data/total-media-category.js
+++ b/static/data/total-media-category.js
@@ -4,6 +4,7 @@ export const TOTAL_MEDIA_CATEGORY = {
             categoryName: "종합/경제",
             media: [
                 {
+                    id: '0',
                     name: "한겨례",
                     iconUrl: "https://s.pstatic.net/static/newsstand/up/2024/0219/nsd145828169.png",
                     editDate: "07월 03일 16:23 편집",
@@ -21,6 +22,7 @@ export const TOTAL_MEDIA_CATEGORY = {
                     ]
                 },
                 {
+                    id: '0',
                     name: "한겨례",
                     iconUrl: "https://s.pstatic.net/static/newsstand/up/2024/0219/nsd145828169.png",
                     editDate: "07월 04일 16:23 편집",
@@ -44,6 +46,7 @@ export const TOTAL_MEDIA_CATEGORY = {
             categoryName: "방송/통신",
             media: [
                 {
+                    id: '1',
                     name: "세계일보",
                     iconUrl: "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/022.png",
                     editDate: "07월 03일 16:23 편집",

--- a/static/data/total-media-category.js
+++ b/static/data/total-media-category.js
@@ -4,11 +4,10 @@ export const TOTAL_MEDIA_CATEGORY = {
             categoryName: "종합/경제",
             media: [
                 {
-                    id: '0',
+                    id: 0,
                     name: "한겨례",
                     iconUrl: "https://s.pstatic.net/static/newsstand/up/2024/0219/nsd145828169.png",
                     editDate: "07월 03일 16:23 편집",
-                    isSubscribed: false,
                     imageContent: {
                         imageUrl: "https://www.pressian.com/_resources/10/2024/07/03/2024070311344319469_l.jpg",
                         url: "https://www.pressian.com/pages/articles/2024070311170206107&amp;utm_source=naver&amp;utm_medium=mynews",
@@ -22,11 +21,10 @@ export const TOTAL_MEDIA_CATEGORY = {
                     ]
                 },
                 {
-                    id: '0',
+                    id: 0,
                     name: "한겨례",
                     iconUrl: "https://s.pstatic.net/static/newsstand/up/2024/0219/nsd145828169.png",
                     editDate: "07월 04일 16:23 편집",
-                    isSubscribed: false,
                     imageContent: {
                         imageUrl: "https://www.pressian.com/_resources/10/2024/07/03/2024070311344319469_l.jpg",
                         url: "https://www.pressian.com/pages/articles/2024070311170206107&amp;utm_source=naver&amp;utm_medium=mynews",
@@ -46,11 +44,10 @@ export const TOTAL_MEDIA_CATEGORY = {
             categoryName: "방송/통신",
             media: [
                 {
-                    id: '1',
+                    id: 1,
                     name: "세계일보",
                     iconUrl: "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/022.png",
                     editDate: "07월 03일 16:23 편집",
-                    isSubscribed: true,
                     imageContent: {
                         imageUrl: "https://it.donga.com/media/__sized__/images/2024/7/3/aafceafdecd94926-thumbnail-1920x1080-70.jpg",
                         url: "https://it.donga.com/105568/",

--- a/static/icons/arrow-right.svg
+++ b/static/icons/arrow-right.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5.48329 10.5L4.66663 9.68333L7.34996 7L4.66663 4.31667L5.48329 3.5L8.98329 7L5.48329 10.5Z" fill="white"/>
+</svg>

--- a/utils/convertToMarkdown.js
+++ b/utils/convertToMarkdown.js
@@ -1,0 +1,24 @@
+/**
+ * @description 입력받은 텍스트를 자체 마크다운 문법에 맞게 변환하는 함수
+ * 
+ * @example 
+ * * \n -> <br/>
+ * * {텍스트} -> <strong>텍스트</strong>
+ */
+export function convertToMarkdown(text, textSize) {
+    let convertedText = text;
+
+    /**
+     * \n -> <br/>
+     */
+    convertedText = convertedText.replace(/\n/g, "<br/>");
+
+    /**
+     * {텍스트} -> <strong>텍스트</strong>
+     */
+    convertedText = convertedText
+                    .replace(/{/g, `<p class="text--strong text__bold${textSize}">`)
+                    .replace(/}/g, "</p>");
+    
+    return `<span class="text--default text__medium${textSize}">${convertedText}</span>`
+}

--- a/utils/events.js
+++ b/utils/events.js
@@ -1,0 +1,5 @@
+export const REMOVE_TOTAL_CATEGORY = "remove-total-category";
+export const removeTotalCategoryEvent = new CustomEvent(REMOVE_TOTAL_CATEGORY);
+
+export const REMOVE_MEDIA_CATEGORY = "remove-media-category";
+export const removeMediaCategoryEvent = new CustomEvent(REMOVE_MEDIA_CATEGORY);

--- a/utils/events.js
+++ b/utils/events.js
@@ -3,3 +3,9 @@ export const removeTotalCategoryEvent = new CustomEvent(REMOVE_TOTAL_CATEGORY);
 
 export const REMOVE_MEDIA_CATEGORY = "remove-media-category";
 export const removeMediaCategoryEvent = new CustomEvent(REMOVE_MEDIA_CATEGORY);
+
+export const REMOVE_TOTAL_ARROW = "remove-total-arrow";
+export const removeTotalArrowEvent = new CustomEvent(REMOVE_TOTAL_ARROW);
+
+export const REMOVE_MEDIA_ARROW = "remove-media-arrow";
+export const removeMediaArrowEvent = new CustomEvent(REMOVE_MEDIA_ARROW);


### PR DESCRIPTION
## 🖥️ Preview


https://github.com/jhj2713/fe-newsstand/assets/76840145/76ce9b12-2d8a-43f1-9a9e-403a5458efe2

## ✔️ 구현 사항
- 최신 뉴스
  - rolling 로직 수정
- 전체 언론사
  - 언론사 구독하기/구독 취소하기
- 내가 구독한 언론사 
  - 로직 연결

## ❓고민했던 부분
### 구독/구독취소 로직

- 로그인을 할 수가 없으니 구독한 언론사를 저장해둘 곳이 마땅치 않다 → 구독한 언론사 목록을 localStorage에 등록해두고 계속 사용할까? (내가 구독한 언론사를 클릭하면 localStorage에서 구독한 언론사 목록 가져오기)
- 전체 언론사가 카테고리별로 데이터가 존재했던 것과는 달리 내가 구독한 언론사는 카테고리 상관 없이 해당 언론사의 모든 기사를 보여주도록 한다 (다른 json을 사용해야할듯)

```markdown
## 구독 로직
전체 언론사에서 구독하기 버튼 클릭
-> 구독 완료 모달과 함께 localStorage에 구독한 언론사 추가
-> 언론사 콘텐츠 다시 로드해서 구독 취소 버튼 나타나게 하기

## 구독 취소 로직
구독 취소 버튼 클릭
-> 구독 취소 모달과 함께 localStorage에서 구독한 언론사 삭제
-> 언론사 콘텐츠 다시 로드해서 구독 취소 버튼 나타나게 하기
```

구독 로직

```jsx
function clickSubscribeButton(categoryIdx, mediaIdx, subscribeMediaId) {
    const subscribeList = JSON.parse(localStorage.getItem("newsstand-subscribe") ?? "[]");
    const newSubscribeList = JSON.stringify([...subscribeList, subscribeMediaId]);
    localStorage.setItem("newsstand-subscribe", newSubscribeList);

    renderMedia(categoryIdx, mediaIdx);
}
```

- 구독 버튼을 클릭하는 경우 localStorage에서 구독한 배열을 꺼내오고 구독할 언론사의 id를 넣어서 새로 저장한다.

구독 취소 로직

```jsx
function clickUnsubscribeButton(categoryIdx, mediaIdx, subscribeMediaId) {
    const subscribeList = JSON.parse(localStorage.getItem("newsstand-subscribe") ?? "[]");
    const newSubscribeList = JSON.stringify(subscribeList.filter((subscribedId) => subscribedId !== subscribeMediaId));
    localStorage.setItem("newsstand-subscribe", newSubscribeList);

    renderMedia(categoryIdx, mediaIdx);
}
```

- 구독 취소 버튼을 클릭하는 경우 localStorage에 저장되어있던 구독한 배열을 꺼내와서 구독되어있던 언론사 id를 제거하고 새로 저장해준다.

### rolling 애니메이션 초기화 로직 수정

```jsx
resetRollingId = setTimeout(() => {
    staticTextDOM.classList.remove('current-news__not-display');
    disappearTextDOM.classList.remove('rolling-out');
    appearTextDOM.classList.remove('rolling-in');

    disappearTextDOM.textContent = rollingData.newsList[prevIdx].title;
    appearTextDOM.textContent = rollingData.newsList[nextIdx].title;
}, 1200);
```

- 처음에는 애니메이션 실행 시간 후에 초기화 하는 setTimeout을 걸어주었는데 이 부분은 불안정한 부분이 많았다. 시간이 오래 걸리는 어떤 작업이 있으면 setTimeout이 원하는 시점에 동작하지 않을 수도 있기 때문이었다.
- 해결 방법이 마땅히 떠오르지 않아 불편한 마음으로 다른 부분 먼저 하고 있었는데, 피어 세션 중 animationend/animationiteration 이벤트가 있다는 걸 알게 되었다. animationend 이벤트는 DOM에 부여된 애니메이션이 끝날때, animationiteration 이벤트는 반복되는 DOM 애니메이션이 돌아갈 때 실행된다.

```jsx
appearTextDOM.addEventListener("animationend", () => {
    staticTextDOM.classList.remove('current-news__not-display');
    disappearTextDOM.classList.remove('rolling-out');
    appearTextDOM.classList.remove('rolling-in');

    disappearTextDOM.textContent = rollingData.newsList[prevIdx].title;
    appearTextDOM.textContent = rollingData.newsList[nextIdx].title;
});
```

- animationend 이벤트를 사용해서 rolling 애니메이션이 끝나는 시점에 초기화를 할 수 있도록 만들어줬다.