### PR TITLE
[Fix] subscribe icon hover 시 src 다르게 나오게 수정

### DIFF
--- a/global-css/components.css
+++ b/global-css/components.css
@@ -70,6 +70,18 @@
 .button__container:hover .button__text {
     color: var(--gray500);
 }
+.button__container .subscribe-button--default {
+    display: block;
+}
+.button__container .subscribe-button--active {
+    display: none;
+}
+.button__container:hover .subscribe-button--default {
+    display: none;
+}
+.button__container:hover .subscribe-button--active {
+    display: block;
+}
 
 .snackbar__wrapper {
     position: absolute;

--- a/media-contents/util.js
+++ b/media-contents/util.js
@@ -54,10 +54,12 @@ export function getSelectedCategoryContentsDOMString(media) {
         <p class="text__medium12">${editDate}</p>
         ${isSubscribed ? `
             <section class="button__container subscribe-button__${id}--unsubscribe" data-media-id="${id}">
-                <img class="subscribe-button__icon--unsubscribe" alt="구독 취소 아이콘" src="./static/icons/close-default.svg" />
+                <img class="subscribe-button__icon--unsubscribe subscribe-button--default" alt="구독 취소 아이콘" src="./static/icons/close-default.svg" />
+                <img class="subscribe-button__icon--unsubscribe subscribe-button--active" alt="구독 취소 아이콘" src="./static/icons/close-hover.svg" />
             </section>` : `
             <section class="button__container subscribe-button__${id}--subscribe" data-media-id="${id}">
-                <img class="subscribe-button__icon" alt="구독 클릭 아이콘" src="./static/icons/plus-default.svg" />
+                <img class="subscribe-button__icon subscribe-button--default" alt="구독 클릭 아이콘" src="./static/icons/plus-default.svg" />
+                <img class="subscribe-button__icon subscribe-button--active" alt="구독 클릭 아이콘" src="./static/icons/plus-hover.svg" />
                 <p class="button__text subscribe-button__text text__medium12 text--weak">구독하기</p>
             </section>`}
     </section>
@@ -91,19 +93,11 @@ export function setSubscribeButtonEvent(media, triggerRender) {
     if (subscribeButtonDOM) {
         const subscribeMediaId = parseInt(subscribeButtonDOM.dataset.mediaId);
         subscribeButtonDOM.addEventListener("click", () => clickSubscribeButton(subscribeMediaId, triggerRender));
-
-        const subscribeButtonIconDOM = subscribeButtonDOM.querySelector(".subscribe-button__icon");
-        subscribeButtonDOM.addEventListener("mouseover", () => subscribeButtonIconDOM.src = "./static/icons/plus-hover.svg");
-        subscribeButtonDOM.addEventListener("mouseout", () => subscribeButtonIconDOM.src = "./static/icons/plus-default.svg");
     }
 
     const unsubscribeButtonDOM = document.querySelector(`.subscribe-button__${media.id}--unsubscribe`);
     if (unsubscribeButtonDOM) {
         unsubscribeButtonDOM.addEventListener("click", () => clickUnsubscribeButton(media, triggerRender));
-        
-        const unsubscribeButtonIconDOM = unsubscribeButtonDOM.querySelector(".subscribe-button__icon--unsubscribe");
-        unsubscribeButtonDOM.addEventListener("mouseover", () => unsubscribeButtonIconDOM.src = "./static/icons/close-hover.svg");
-        unsubscribeButtonDOM.addEventListener("mouseout", () => unsubscribeButtonIconDOM.src = "./static/icons/close-default.svg");
     }
 }
 
@@ -160,11 +154,13 @@ export function getGridMediaItem(media) {
                 <img class="media-contents__grid-item-icon" alt="${media.name} 언론사 아이콘" src="${media.icon}"/>
                 ${isSubscribed ? `
                 <section class="button__container subscribe-button__${media.id}--unsubscribe" data-media-id="${media.id}">
-                    <img class="subscribe-button__icon--unsubscribe" alt="구독 취소 아이콘" src="./static/icons/close-default.svg" />
+                    <img class="subscribe-button__icon--unsubscribe subscribe-button--default" alt="구독 취소 아이콘" src="./static/icons/close-default.svg" />
+                    <img class="subscribe-button__icon--unsubscribe subscribe-button--active" alt="구독 취소 아이콘" src="./static/icons/close-hover.svg" />
                     <p class="button__text subscribe-button__text text__medium12 text--weak">해지하기</p>
                 </section>` : `
                 <section class="button__container subscribe-button__${media.id}--subscribe" data-media-id="${media.id}">
-                    <img class="subscribe-button__icon" alt="구독 클릭 아이콘" src="./static/icons/plus-default.svg" />
+                    <img class="subscribe-button__icon subscribe-button--default" alt="구독 클릭 아이콘" src="./static/icons/plus-default.svg" />
+                    <img class="subscribe-button__icon subscribe-button--active" alt="구독 클릭 아이콘" src="./static/icons/plus-hover.svg" />
                     <p class="button__text subscribe-button__text text__medium12 text--weak">구독하기</p>
                 </section>`}
             </li>`


### PR DESCRIPTION
## ✔️ 구현 사항
- 구독하기/해지하기 icon hover 시 src 다르게 나오게 수정

## ❓ 고민한 사항

### 구독하기/해지하기 아이콘 hover 처리

1. 처음에는 JS에서 mouseover 이벤트를 사용해서 처리했다. mouseover 이벤트가 발생하면 icon의 src를 hover 아이콘으로 바꿔주고, mouseout 이벤트가 발생하면 icon의 src를 default 아이콘으로 바꿔준다.
    
    ```
    subscribeButtonDOM.addEventListener("mouseover", () => subscribeButtonIconDOM.src = "./static/icons/plus-hover.svg");
    subscribeButtonDOM.addEventListener("mouseout", () => subscribeButtonIconDOM.src = "./static/icons/plus-default.svg");
    ```
    
    이렇게 하니까 동작은 잘 했다. 그런데 문제는 그리드를 구현할 때 발생했다. 그리드는 그리드 아이템을 hover 했을 때 구독하기/해지하기 버튼이 나타나고, 이때 구독하기/해지하기 버튼을 hover 하면 아이콘이 바뀌게 된다. 
    
    결국 위와 같이 처리해주려면 그리드 아이템에 mouseover 이벤트 리스너 붙이고, 이 이벤트 리스너에서 button에 mouseover 이벤트 리스너를 붙여서 처리를 해줘야한다. 너무 복잡해서 그냥 다른 방식으로 처리하고 싶었다.
    
2. 그래서 그냥 그리드와 리스트가 DOM에 각 껍질은 넣어두고 display를 사용해서 가시성을 조절한 것처럼 구현해보기로 했다.
    
    ```jsx
    <img class="subscribe-button__icon--unsubscribe subscribe-button--default" alt="구독 취소 아이콘" src="./static/icons/close-default.svg" />
    <img class="subscribe-button__icon--unsubscribe subscribe-button--active" alt="구독 취소 아이콘" src="./static/icons/close-hover.svg" />
    
    .button__container .subscribe-button--default {
        display: block;
    }
    .button__container .subscribe-button--active {
        display: none;
    }
    .button__container:hover .subscribe-button--default {
        display: none;
    }
    .button__container:hover .subscribe-button--active {
        display: block;
    }
    ```
    
    default 아이콘, hover 아이콘 두 개 모두 DOM에 올려놓고 `display` 를 사용해서 hover 시 hover 아이콘이 보여질 수 있도록 했다.