### PR TITLE
[Refactor] 구독 목록 저장 방식을 localStorage에서 store로 수정

### DIFF
--- a/media-contents/subscribed-media.js
+++ b/media-contents/subscribed-media.js
@@ -151,8 +151,8 @@ function renderListMedia(mediaId) {
     /**
      * 언론사 카테고리 렌더링
      */
-    const selectedMedia = mediaId ?? subscribedMediaList.data[0];
-    const _selectedMediaIdx = subscribedMediaList.data.findIndex((media) => media.id === selectedMedia.id);
+    const selectedMediaId = mediaId ?? subscribedMediaList.data[0].id;
+    const _selectedMediaIdx = subscribedMediaList.data.findIndex((media) => media.id === selectedMediaId);
     const selectedMediaIdx = _selectedMediaIdx === -1 ? 0 : _selectedMediaIdx;
 
     let mediaListDOMString = ''
@@ -184,7 +184,7 @@ function renderListMedia(mediaId) {
     const contentsString = getSelectedCategoryContentsDOMString(subscribedMediaDetailList[selectedMediaIdx]);
     contentsBoxDOM.innerHTML = contentsString;
 
-    subscribedMediaList.addCallback(() => renderListMedia(selectedMedia.id));
+    subscribedMediaList.addCallback(() => renderListMedia(selectedMediaId));
     setSubscribeButtonEvent(subscribedMediaList.data[selectedMediaIdx]);
 }
 
@@ -203,7 +203,7 @@ function clickMediaList(e) {
         return;
     }
 
-    renderListMedia(subscribedMediaList.data[mediaIdx]);
+    renderListMedia(subscribedMediaList.data[mediaIdx].id);
 }
 
 /**

--- a/media-contents/subscribed-media.js
+++ b/media-contents/subscribed-media.js
@@ -1,6 +1,6 @@
+import { subscribedMediaList } from "../store/subscribed-media.js";
 import { getData } from "../utils/fetch.js";
 import { getBoundNumber } from "../utils/get-number.js";
-import { getItem } from "../utils/local-storage.js";
 import { DATA_COUNT_PER_GRID, DEFAULT_MEDIA_INDEX, DEFAULT_PAGE } from "./constant.js";
 import { 
     getSelectedCategoryItemDOMString,
@@ -12,14 +12,14 @@ import {
     clickGridItem,
 } from "./util.js";
 
-let mediaData = {};
+let mediaDetailData = {};
 let mediaListData = {};
 
 /**
  * @description 구독한 언론사를 렌더링하는 함수
  */
 export async function renderSubscribedMedia() {
-    mediaData = await getData('../static/data/media-detail.json');
+    mediaDetailData = await getData('../static/data/media-detail.json');
     mediaListData = await getData('../static/data/media.json');
 
     const displayMode = getDisplayMode();
@@ -103,8 +103,7 @@ function setArrowDisplayInGrid(page) {
     const prevMediaButton = document.querySelector(".media-contents__left-button");
     const nextMediaButton = document.querySelector(".media-contents__right-button");
 
-    const subscribeIdList = getItem("newsstand-subscribe") ?? [];
-    const maxPage = Math.floor((subscribeIdList.length - 1) / DATA_COUNT_PER_GRID);
+    const maxPage = Math.floor((subscribedMediaList.getSubscribedMediaLength() - 1) / DATA_COUNT_PER_GRID);
 
     if (page === 0) {
         prevMediaButton.classList.add("non-display");
@@ -124,16 +123,14 @@ function setArrowDisplayInGrid(page) {
 function renderGridMedia(page) {
     const gridListDOM = document.querySelector(".media-contents__grid-list");
 
-    const subscribeIdList = getItem("newsstand-subscribe") ?? [];
-    const media = subscribeIdList.map((subscribedId) => mediaListData.data.find((_media) => _media.id === subscribedId));
-
     let mediaListDOMString = '';
-    media.slice(page * DATA_COUNT_PER_GRID, (page + 1) * DATA_COUNT_PER_GRID).forEach((_media) => {
+    subscribedMediaList.data.slice(page * DATA_COUNT_PER_GRID, (page + 1) * DATA_COUNT_PER_GRID).forEach((_media) => {
         mediaListDOMString += getGridMediaItem(_media);
     });
 
     gridListDOM.innerHTML = mediaListDOMString;
 
+    subscribedMediaList.addCallback(() => renderGridMedia(page));
     setArrowDisplayInGrid(page);
 }
 
@@ -141,14 +138,11 @@ function renderGridMedia(page) {
  * @description 내가 구독한 언론사를 리스트 형식으로 렌더링하는 함수
  */
 function renderListMedia(mediaId) {
-    const media = mediaData.data;
-    const subscribeIdList = getItem("newsstand-subscribe") ?? [];
-    const subscribedMediaList = subscribeIdList.map((subscribed) => media.find((_media) => _media.id === subscribed));
-
     const mediaListDOM = document.querySelector(".media-contents__category-list");
     const contentsBoxDOM = document.querySelector(".media-contents__contents-box");
+    const subscribedMediaDetailList = subscribedMediaList.data.map((subscribed) => mediaDetailData.data.find((_media) => _media.id === subscribed.id))
 
-    if (subscribedMediaList.length === 0) {
+    if (subscribedMediaList.getSubscribedMediaLength() === 0) {
         mediaListDOM.innerHTML = "";
         contentsBoxDOM.innerHTML = "";
         return;
@@ -157,12 +151,12 @@ function renderListMedia(mediaId) {
     /**
      * 언론사 카테고리 렌더링
      */
-    const selectedMediaId = mediaId ?? subscribeIdList[0];
-    const _selectedMediaIdx = subscribedMediaList.findIndex((media) => media.id === selectedMediaId);
+    const selectedMedia = mediaId ?? subscribedMediaList.data[0];
+    const _selectedMediaIdx = subscribedMediaList.data.findIndex((media) => media.id === selectedMedia.id);
     const selectedMediaIdx = _selectedMediaIdx === -1 ? 0 : _selectedMediaIdx;
 
     let mediaListDOMString = ''
-    subscribedMediaList.forEach((_media, _mediaIdx) => {
+    subscribedMediaDetailList.forEach((_media, _mediaIdx) => {
         if (_mediaIdx === selectedMediaIdx) {
             /**
              * 선택된 카테고리인 경우
@@ -187,10 +181,11 @@ function renderListMedia(mediaId) {
     /**
      * 선택된 카테고리의 콘텐츠 렌더링
      */
-    const contentsString = getSelectedCategoryContentsDOMString(subscribedMediaList[selectedMediaIdx]);
+    const contentsString = getSelectedCategoryContentsDOMString(subscribedMediaDetailList[selectedMediaIdx]);
     contentsBoxDOM.innerHTML = contentsString;
 
-    setSubscribeButtonEvent(subscribedMediaList[selectedMediaIdx], () => renderListMedia(selectedMediaId));
+    subscribedMediaList.addCallback(() => renderListMedia(selectedMedia.id));
+    setSubscribeButtonEvent(subscribedMediaList.data[selectedMediaIdx]);
 }
 
 /**
@@ -208,10 +203,7 @@ function clickMediaList(e) {
         return;
     }
 
-    const subscribeIdList = getItem("newsstand-subscribe") ?? [];
-    const mediaId = subscribeIdList.find((_, idx) => idx === mediaIdx);
-
-    renderListMedia(mediaId);
+    renderListMedia(subscribedMediaList.data[mediaIdx]);
 }
 
 /**
@@ -242,10 +234,10 @@ function navigatePrevMedia() {
 /**
  * @description 리스트 보기에서 prev, next 버튼 클릭 동작을 수행하는 함수
  */
-function clickListNavigationButton(step) {
-    const subscribeIdList = getItem("newsstand-subscribe") ?? [];
+function clickListNavigationButton(step) { 
+    const mediaLength = subscribedMediaList.getSubscribedMediaLength();
 
-    if (subscribeIdList.length === 0) {
+    if (mediaLength === 0) {
         return;
     }
 
@@ -260,8 +252,8 @@ function clickListNavigationButton(step) {
         /**
          * 첫 카테고리에 다다른 경우 마지막 카테고리로 이동
          */
-        nextCategoryIdx = subscribeIdList.length - 1;
-    } else if (nextCategoryIdx === subscribeIdList.length) {
+        nextCategoryIdx = mediaLength - 1;
+    } else if (nextCategoryIdx === mediaLength) {
         /**
          * 마지막 카테고리에 다다른 경우 첫 카테고리로 이동
          */
@@ -269,8 +261,8 @@ function clickListNavigationButton(step) {
     }
 
     selectedCategory.dataset.selectedCategoryIdx = nextCategoryIdx;
-    const nextCategoryId = subscribeIdList[nextCategoryIdx];
-    renderListMedia(nextCategoryId);
+    const nextCategory = subscribedMediaList.data[nextCategoryIdx];
+    renderListMedia(nextCategory.id);
 }
 
 /**
@@ -280,8 +272,7 @@ function clickGridNavigationButton(step) {
     const gridBoxDOM = document.querySelector(".media-contents__grid-box");
     const currentPage = parseInt(gridBoxDOM.dataset.gridPage);
 
-    const subscribeIdList = getItem("newsstand-subscribe") ?? [];
-    const media = subscribeIdList.map((subscribedId) => mediaListData.data.find((_media) => _media.id === subscribedId));
+    const media = subscribedMediaList.data.map((subscribed) => mediaListData.data.find((_media) => _media.id === subscribed.id));
     const mediaLength = media.length;
     const nextPage = getBoundNumber(currentPage + step, 0, Math.floor((mediaLength - 1) / DATA_COUNT_PER_GRID));
 

--- a/media-contents/subscribed-media.js
+++ b/media-contents/subscribed-media.js
@@ -130,7 +130,7 @@ function renderGridMedia(page) {
 
     gridListDOM.innerHTML = mediaListDOMString;
 
-    subscribedMediaList.addCallback(() => renderGridMedia(page));
+    subscribedMediaList.setCallback(() => renderGridMedia(page));
     setArrowDisplayInGrid(page);
 }
 
@@ -184,7 +184,7 @@ function renderListMedia(mediaId) {
     const contentsString = getSelectedCategoryContentsDOMString(subscribedMediaDetailList[selectedMediaIdx]);
     contentsBoxDOM.innerHTML = contentsString;
 
-    subscribedMediaList.addCallback(() => renderListMedia(selectedMediaId));
+    subscribedMediaList.setCallback(() => renderListMedia(selectedMediaId));
     setSubscribeButtonEvent(subscribedMediaList.data[selectedMediaIdx]);
 }
 

--- a/media-contents/total-media.js
+++ b/media-contents/total-media.js
@@ -131,7 +131,7 @@ function renderGridMedia(page) {
 
     gridListDOM.innerHTML = mediaListDOMString;
 
-    subscribedMediaList.addCallback(() => renderGridMedia(page));
+    subscribedMediaList.setCallback(() => renderGridMedia(page));
     setArrowDisplayInGrid(page);
 }
 
@@ -175,7 +175,7 @@ function renderListMedia(categoryIdx, mediaIdx) {
     const contentsString = getSelectedCategoryContentsDOMString(category[categoryIdx].media[mediaIdx]);
     contentsBoxDOM.innerHTML = contentsString;
 
-    subscribedMediaList.addCallback(() => renderListMedia(categoryIdx, mediaIdx));
+    subscribedMediaList.setCallback(() => renderListMedia(categoryIdx, mediaIdx));
     setSubscribeButtonEvent(category[categoryIdx].media[mediaIdx]);
 }
 

--- a/media-contents/total-media.js
+++ b/media-contents/total-media.js
@@ -1,3 +1,4 @@
+import { subscribedMediaList } from "../store/subscribed-media.js";
 import { getData } from "../utils/fetch.js";
 import { getBoundNumber } from "../utils/get-number.js";
 import { DATA_COUNT_PER_GRID, DEFAULT_CATEGORY_INDEX, DEFAULT_MEDIA_INDEX, DEFAULT_PAGE } from "./constant.js";
@@ -130,6 +131,7 @@ function renderGridMedia(page) {
 
     gridListDOM.innerHTML = mediaListDOMString;
 
+    subscribedMediaList.addCallback(() => renderGridMedia(page));
     setArrowDisplayInGrid(page);
 }
 
@@ -173,7 +175,8 @@ function renderListMedia(categoryIdx, mediaIdx) {
     const contentsString = getSelectedCategoryContentsDOMString(category[categoryIdx].media[mediaIdx]);
     contentsBoxDOM.innerHTML = contentsString;
 
-    setSubscribeButtonEvent(category[categoryIdx].media[mediaIdx], () => renderListMedia(categoryIdx, mediaIdx));
+    subscribedMediaList.addCallback(() => renderListMedia(categoryIdx, mediaIdx));
+    setSubscribeButtonEvent(category[categoryIdx].media[mediaIdx]);
 }
 
 /**
@@ -292,8 +295,6 @@ function clickGridList(e) {
     if (displayMode === "list-display") {
         return;
     }
-    const gridBoxDOM = document.querySelector(".media-contents__grid-box");
-    const currentPage = parseInt(gridBoxDOM.dataset.gridPage);
 
-    return clickGridItem(e, mediaListData.data, () => renderGridMedia(currentPage));
+    return clickGridItem(e, mediaListData.data);
 }

--- a/store/subscribed-media.js
+++ b/store/subscribed-media.js
@@ -12,15 +12,15 @@ class SubscribedMedia {
         this.data = this.data.filter((_data) => _data.id !== media.id);
         this.processCallback();
     }
+
     isSubscribed(mediaId) {
         return !!this.data.find((_data) => _data.id === mediaId);
     }
-
     getSubscribedMediaLength() {
         return this.data.length;
     }
 
-    addCallback(callback) {
+    setCallback(callback) {
         this.callback = callback;
     }
     processCallback() {

--- a/store/subscribed-media.js
+++ b/store/subscribed-media.js
@@ -1,0 +1,34 @@
+class SubscribedMedia {
+    constructor() {
+        this.data = [];
+        this.callback = null;
+    }
+
+    addMedia(media) {
+        this.data.push(media);
+        this.processCallback();
+    }
+    deleteMedia(media) {
+        this.data = this.data.filter((_data) => _data.id !== media.id);
+        this.processCallback();
+    }
+    isSubscribed(mediaId) {
+        return !!this.data.find((_data) => _data.id === mediaId);
+    }
+
+    getSubscribedMediaLength() {
+        return this.data.length;
+    }
+
+    addCallback(callback) {
+        this.callback = callback;
+    }
+    processCallback() {
+        if (this.callback) {
+            this.callback();
+        }
+    }
+}
+
+const subscribedMediaList = new SubscribedMedia();
+export { subscribedMediaList };


### PR DESCRIPTION
## 🖥️ Preview

https://github.com/jhj2713/fe-newsstand/assets/76840145/897b323b-cf9f-411e-8353-ccb6d61cf41d

## ✔️ 구현 사항
- store 구현

## ❓ 고민한 사항

**as-is**

- 구독 목록을 로컬 스토리지에 저장해두고 구독하거나 해지하는 클릭 이벤트가 발생하면 로컬 스토리지의 상태를 변화시켰다.

```jsx
/**
 * @description 구독/구독취소 이벤트 등록하는 함수
 */
export function setSubscribeButtonEvent(media, triggerRender) {  
    subscribeButtonDOM.addEventListener("click", () => clickSubscribeButton(media, triggerRender));
    unsubscribeButtonDOM.addEventListener("click", () => clickUnsubscribeButton(media, triggerRender));
}

```

- 로그인이 없다보니 창을 닫았다가 다시 열어도 구독 상태를 유지시킬 수 있는 방법이 localStorage밖에 없다고 생각해서 이런 방식으로 구현했었다. 그런데 불편했던 점은 로컬 스토리지의 상태가 변하면 해당 상태를 보여주는 화면을 다시 렌더해야하기 때문에 `triggerRender`를 받아서 클릭될 때 실행하도록 해야했다.

**to-be**

- 프로그래밍 요구사항에 스토어로 구현하기가 있어서 활용할 수 있는 방법이 있을까 생각해보다가 구독 목록에 활용할 수 있겠다는 생각이 들었다.

```jsx
class SubscribedMedia {
    constructor() {
        this.data = [];
        this.callback = null;
    }
    ...
    addCallback(callback) {
        this.callback = callback;
    }
    processCallback() {
        if (this.callback) {
            this.callback();
        }
    }
}

const subscribedMediaList = new SubscribedMedia();
export { subscribedMediaList };
```

- 물론 localStorage를 활용하지 않으면 창을 닫았다가 열었을 때 구독 상태가 유지되지는 않지만 화면이 다시 렌더되는 콜백을 등록해두면 굳이 `triggerRender`를 전달하지 않아도 구독 상태가 바뀌었을때 바뀐 상태를 잘 보여줄 수 있기 때문에 훨씬 더 편리하다.
- 콜백도 배열로 받아서 돌리면서 실행하도록 해보고 싶었는데, 일단 구독 목록의 경우 하나의 콘텐츠 렌더만 콜백으로 등록해주면 돼서 그럴 필요가 없기도 했고 그리드/리스트 보기의 경우 다르게 콜백이 들어가야해서 초기화 로직까지 더해져야하다 보니까 약간 더 복잡해지는 것 같아서 일단 여기서는 뺐다. 다른 스토어가 추가되면 그때는 배열로 돌리는 것도 고려해볼 예정이다.