### PR TITLE
[Feat] 세부 요구사항 반영

### DIFF
--- a/header/index.js
+++ b/header/index.js
@@ -5,6 +5,9 @@ function initHeader() {
     const currentDateDOM = document.querySelector('#header__current-date');
     
     currentDateDOM.textContent = currentDate;
+
+    const newsstandIconDOM = document.querySelector("#newsstand-icon");
+    newsstandIconDOM.addEventListener("click", () => location.reload());
 }
 
 initHeader();

--- a/index.html
+++ b/index.html
@@ -10,10 +10,10 @@
 <body class="flexbox__column-direction gap40">
     <header>
         <section class="flexbox__space-between--center">
-            <section class="flexbox__flex-start--center gap8">
+            <button id="newsstand-icon" class="flexbox__flex-start--center gap8">
                 <img alt="뉴스스탠드 아이콘" src="./static/icons/newspaper.svg"/>
                 <h1 class="text__bold24 text--strong">뉴스스탠드</h1>
-            </section>
+            </button>
             <p id="header__current-date" class="text__medium16"></p>
         </section>
     </header>

--- a/media-contents/get-data.js
+++ b/media-contents/get-data.js
@@ -1,3 +1,4 @@
+import { mediaCategory } from '../store/media-category.js';
 import { mediaDetail } from '../store/media-detail.js';
 import { mediaList } from '../store/media-list.js';
 import { getData } from '../utils/fetch.js';
@@ -19,4 +20,17 @@ export async function getMediaData() {
      */
     const mediaDetailData = await getData('../static/data/media-detail.json');
     mediaDetail.setData(mediaDetailData.data);
+
+    /**
+     * 카테고리별 언론사 목록
+     */
+    const categoryData = await getData('../static/data/media-by-category.json');
+    const shuffledCategory = categoryData.data.map((_data) => {
+        const shuffledMediaList = shuffleList(_data.media.slice());
+        return {
+            ..._data,
+            media: shuffledMediaList
+        }
+    });
+    mediaCategory.setData(shuffledCategory);
 }

--- a/media-contents/get-data.js
+++ b/media-contents/get-data.js
@@ -1,3 +1,4 @@
+import { mediaDetail } from '../store/media-detail.js';
 import { mediaList } from '../store/media-list.js';
 import { getData } from '../utils/fetch.js';
 import { shuffleList } from '../utils/shuffle-list.js';
@@ -6,7 +7,16 @@ import { shuffleList } from '../utils/shuffle-list.js';
  * @description 데이터를 패치하는 함수
  */
 export async function getMediaData() {
+    /**
+     * media 목록
+     */
     const mediaListData = await getData('../static/data/media.json');
     const shuffledMediaList = shuffleList(mediaListData.data.slice());
     mediaList.setData(shuffledMediaList);
+
+    /**
+     * media 상세 콘텐츠
+     */
+    const mediaDetailData = await getData('../static/data/media-detail.json');
+    mediaDetail.setData(mediaDetailData.data);
 }

--- a/media-contents/get-data.js
+++ b/media-contents/get-data.js
@@ -1,0 +1,12 @@
+import { mediaList } from '../store/media-list.js';
+import { getData } from '../utils/fetch.js';
+import { shuffleList } from '../utils/shuffle-list.js';
+
+/**
+ * @description 데이터를 패치하는 함수
+ */
+export async function getMediaData() {
+    const mediaListData = await getData('../static/data/media.json');
+    const shuffledMediaList = shuffleList(mediaListData.data.slice());
+    mediaList.setData(shuffledMediaList);
+}

--- a/media-contents/index.css
+++ b/media-contents/index.css
@@ -68,7 +68,11 @@
 
 .media-contents__image-content {
     width: 320px;
-    cursor: pointer;
+}
+.media-contents__image-wrapper {
+    width: 320px;
+    height: 200px;
+    overflow: hidden;
 }
 .media-contents__image-content img {
     width: 320px;

--- a/media-contents/index.js
+++ b/media-contents/index.js
@@ -2,11 +2,11 @@ import { renderMediaFilter } from "./media-filter.js";
 import { renderGridLayout, renderMediaDisplay } from "./media-display.js";
 import { getMediaData } from "./get-data.js";
 
-function initMediaContents() {
+async function initMediaContents() {
     /**
      * 데이터 패치
      */
-    getMediaData();
+    await getMediaData();
 
     /**
      * 언론사 필터 렌더링

--- a/media-contents/index.js
+++ b/media-contents/index.js
@@ -1,7 +1,13 @@
 import { renderMediaFilter } from "./media-filter.js";
 import { renderGridLayout, renderMediaDisplay } from "./media-display.js";
+import { getMediaData } from "./get-data.js";
 
 function initMediaContents() {
+    /**
+     * 데이터 패치
+     */
+    getMediaData();
+
     /**
      * 언론사 필터 렌더링
      */

--- a/media-contents/media-display.js
+++ b/media-contents/media-display.js
@@ -17,20 +17,13 @@ export function renderMediaDisplay() {
  */
 function clickMediaDisplay(e) {
     const displayId = e.target.id;
-    const mediaDisplayDOM = document.querySelector("#display-style");
     const mediaFilterDOM = document.querySelector("#media-filter");
     const selectedFilter = mediaFilterDOM.dataset.selectedFilter;
 
     if (displayId === "list-display") {
-        setSelectedDisplay("list-display");
-        setUnelectedDisplay("grid-display");
-        
-        mediaDisplayDOM.dataset.selectedDisplay = "list-display";
+        setListDisplay();
     } else if (displayId === "grid-display") {
-        setSelectedDisplay("grid-display");
-        setUnelectedDisplay("list-display");
-
-        mediaDisplayDOM.dataset.selectedDisplay = "grid-display";
+        setGridDisplay();
     }
 
     if (selectedFilter === "total-media") {
@@ -40,6 +33,29 @@ function clickMediaDisplay(e) {
         resetTotalMedia();
         renderSubscribedMedia();
     }
+}
+
+/**
+ * @description 리스트 보기로 전환해주는 함수
+ */
+export function setListDisplay() {
+    const mediaDisplayDOM = document.querySelector("#display-style");
+
+    setSelectedDisplay("list-display");
+    setUnelectedDisplay("grid-display");
+    
+    mediaDisplayDOM.dataset.selectedDisplay = "list-display";
+}
+/**
+ * @description 그리드 보기로 전환해주는 함수
+ */
+export function setGridDisplay() {
+    const mediaDisplayDOM = document.querySelector("#display-style");
+
+    setSelectedDisplay("grid-display");
+    setUnelectedDisplay("list-display");
+
+    mediaDisplayDOM.dataset.selectedDisplay = "grid-display";
 }
 
 /**

--- a/media-contents/media-filter.js
+++ b/media-contents/media-filter.js
@@ -29,23 +29,40 @@ function clickMediaFilter(e) {
  * @description 필터에 맞는 언론사 콘텐츠를 렌더하는 함수
  */
 function renderMediaContents(mediaId) {
-    const filterMediaDOM = document.querySelector("#media-filter");
-
     if (mediaId === "total-media") {
-        filterMediaDOM.dataset.selectedFilter = "total-media";
-        setSelectedMedia("total-media");
-        setUnselectedMedia("subscribed-media");
-
-        resetSubscribedMedia();
+        setTotalMedia();
         renderTotalMedia();
     } else if (mediaId === "subscribed-media") {
-        filterMediaDOM.dataset.selectedFilter = "subscribed-media";
-        setSelectedMedia("subscribed-media");
-        setUnselectedMedia("total-media");
-        
-        resetTotalMedia();
+        setSubscribedMedia();
         renderSubscribedMedia();
     }
+}
+
+/**
+ * @description 전체 언론사로 전환해주는 함수
+ */
+export function setTotalMedia() {
+    const filterMediaDOM = document.querySelector("#media-filter");
+
+    setSelectedMedia("total-media");
+    setUnselectedMedia("subscribed-media");
+
+    filterMediaDOM.dataset.selectedFilter = "total-media";
+
+    resetSubscribedMedia();
+}
+/**
+ * @description 내가 구독한 언론사로 전환해주는 함수
+ */
+export function setSubscribedMedia() {
+    const filterMediaDOM = document.querySelector("#media-filter");
+
+    setSelectedMedia("subscribed-media");
+    setUnselectedMedia("total-media");
+
+    filterMediaDOM.dataset.selectedFilter = "subscribed-media";
+
+    resetTotalMedia();
 }
 
 /**

--- a/media-contents/subscribed-media.js
+++ b/media-contents/subscribed-media.js
@@ -103,7 +103,9 @@ function setArrowDisplayInGrid(page) {
     const prevMediaButton = document.querySelector(".media-contents__left-button");
     const nextMediaButton = document.querySelector(".media-contents__right-button");
 
-    const maxPage = Math.floor((subscribedMediaList.getSubscribedMediaLength() - 1) / DATA_COUNT_PER_GRID);
+    const lastPage = Math.floor((subscribedMediaList.getSubscribedMediaLength() - 1) / DATA_COUNT_PER_GRID);
+    const maxPage = lastPage >= 4 ? 3 : lastPage;
+
 
     if (page === 0) {
         prevMediaButton.classList.add("non-display");

--- a/media-contents/subscribed-media.js
+++ b/media-contents/subscribed-media.js
@@ -1,3 +1,4 @@
+import { mediaList } from "../store/media-list.js";
 import { subscribedMediaList } from "../store/subscribed-media.js";
 import { getData } from "../utils/fetch.js";
 import { getBoundNumber } from "../utils/get-number.js";
@@ -13,14 +14,12 @@ import {
 } from "./util.js";
 
 let mediaDetailData = {};
-let mediaListData = {};
 
 /**
  * @description 구독한 언론사를 렌더링하는 함수
  */
 export async function renderSubscribedMedia(mediaId) {
     mediaDetailData = await getData('../static/data/media-detail.json');
-    mediaListData = await getData('../static/data/media.json');
 
     const displayMode = getDisplayMode();
 
@@ -274,7 +273,7 @@ function clickGridNavigationButton(step) {
     const gridBoxDOM = document.querySelector(".media-contents__grid-box");
     const currentPage = parseInt(gridBoxDOM.dataset.gridPage);
 
-    const media = subscribedMediaList.data.map((subscribed) => mediaListData.data.find((_media) => _media.id === subscribed.id));
+    const media = subscribedMediaList.data.map((subscribed) => mediaList.findMediaById(subscribed.id));
     const mediaLength = media.length;
     const nextPage = getBoundNumber(currentPage + step, 0, Math.floor((mediaLength - 1) / DATA_COUNT_PER_GRID));
 
@@ -292,5 +291,5 @@ function clickGridList(e) {
         return;
     }
 
-    return clickGridItem(e, mediaListData.data);
+    return clickGridItem(e);
 }

--- a/media-contents/subscribed-media.js
+++ b/media-contents/subscribed-media.js
@@ -171,6 +171,11 @@ function renderListMedia(mediaId) {
     progressAnimationDOM.addEventListener("animationiteration", navigateNextMedia);
 
     /**
+     * 선택된 언론사로 스크롤
+     */
+    scrollToSelectedMedia();
+
+    /**
      * 카테고리 이벤트 리스너 등록
      */
     mediaListDOM.addEventListener('click', clickMediaList);
@@ -288,4 +293,20 @@ function clickGridList(e) {
     }
 
     return clickGridItem(e);
+}
+
+/**
+ * @description 선택된 언론사로 스크롤하는 함수
+ */
+function scrollToSelectedMedia() {
+    const mediaListDOM = document.querySelector(".media-contents__category-list");
+    const categoryListDOM = document.querySelector(".media-contents__category-list");
+    const selectedMediaDOM = mediaListDOM.querySelector(".media-contents__category-item--selected");
+    
+    const { width: selectedMediaWidth, left: selectedMediaLeft } = selectedMediaDOM.getBoundingClientRect();
+    const { width: categoryListWidth, left: categoryListLeft } = categoryListDOM.getBoundingClientRect();
+
+    const scroll = selectedMediaLeft - categoryListLeft - categoryListWidth + selectedMediaWidth;
+
+    categoryListDOM.scrollBy({ left: scroll });
 }

--- a/media-contents/subscribed-media.js
+++ b/media-contents/subscribed-media.js
@@ -1,6 +1,6 @@
+import { mediaDetail } from "../store/media-detail.js";
 import { mediaList } from "../store/media-list.js";
 import { subscribedMediaList } from "../store/subscribed-media.js";
-import { getData } from "../utils/fetch.js";
 import { getBoundNumber } from "../utils/get-number.js";
 import { DATA_COUNT_PER_GRID, DEFAULT_MEDIA_INDEX, DEFAULT_PAGE } from "./constant.js";
 import { 
@@ -13,14 +13,10 @@ import {
     clickGridItem,
 } from "./util.js";
 
-let mediaDetailData = {};
-
 /**
  * @description 구독한 언론사를 렌더링하는 함수
  */
 export async function renderSubscribedMedia(mediaId) {
-    mediaDetailData = await getData('../static/data/media-detail.json');
-
     const displayMode = getDisplayMode();
 
     const gridBoxDOM = document.querySelector(".media-contents__grid-box");
@@ -141,7 +137,7 @@ function renderGridMedia(page) {
 function renderListMedia(mediaId) {
     const mediaListDOM = document.querySelector(".media-contents__category-list");
     const contentsBoxDOM = document.querySelector(".media-contents__contents-box");
-    const subscribedMediaDetailList = subscribedMediaList.data.map((subscribed) => mediaDetailData.data.find((_media) => _media.id === subscribed.id))
+    const subscribedMediaDetailList = subscribedMediaList.data.map((subscribed) => mediaDetail.findMediaById(subscribed.id));
 
     if (subscribedMediaList.getSubscribedMediaLength() === 0) {
         mediaListDOM.innerHTML = "";

--- a/media-contents/subscribed-media.js
+++ b/media-contents/subscribed-media.js
@@ -18,7 +18,7 @@ let mediaListData = {};
 /**
  * @description 구독한 언론사를 렌더링하는 함수
  */
-export async function renderSubscribedMedia() {
+export async function renderSubscribedMedia(mediaId) {
     mediaDetailData = await getData('../static/data/media-detail.json');
     mediaListData = await getData('../static/data/media.json');
 
@@ -31,7 +31,7 @@ export async function renderSubscribedMedia() {
         gridBoxDOM.classList.add("non-display");
         listBoxDOM.classList.remove("non-display");
 
-        renderListMedia();
+        renderListMedia(mediaId);
     } else if (displayMode === "grid-display") {
         gridBoxDOM.classList.remove("non-display");
         listBoxDOM.classList.add("non-display");

--- a/media-contents/total-media.js
+++ b/media-contents/total-media.js
@@ -1,7 +1,7 @@
 import { subscribedMediaList } from "../store/subscribed-media.js";
 import { getData } from "../utils/fetch.js";
 import { getBoundNumber } from "../utils/get-number.js";
-import { shuffleList } from "../utils/shuffle-list.js";
+import { mediaList } from "../store/media-list.js";
 import { DATA_COUNT_PER_GRID, DEFAULT_CATEGORY_INDEX, DEFAULT_MEDIA_INDEX, DEFAULT_PAGE } from "./constant.js";
 import { renderSubscribedMedia } from "./subscribed-media.js";
 import { 
@@ -15,15 +15,12 @@ import {
 } from "./util.js";
 
 let categoryData = {};
-let mediaListData = {};
 
 /**
  * @description 전체 언론사를 렌더링하는 함수
  */
 export async function renderTotalMedia() {
     categoryData = await getData('../static/data/media-by-category.json');
-    mediaListData = await getData('../static/data/media.json');
-    mediaListData.data = shuffleList(mediaListData.data.slice());
 
     const displayMode = getDisplayMode();
 
@@ -106,7 +103,7 @@ function setArrowDisplayInGrid(page) {
     const prevMediaButton = document.querySelector(".media-contents__left-button");
     const nextMediaButton = document.querySelector(".media-contents__right-button");
 
-    const lastPage = Math.floor((mediaListData.data.length - 1) / DATA_COUNT_PER_GRID);
+    const lastPage = Math.floor((mediaList.getLength() - 1) / DATA_COUNT_PER_GRID);
     const maxPage = lastPage >= 4 ? 3 : lastPage;
 
     if (page === 0) {
@@ -125,7 +122,7 @@ function setArrowDisplayInGrid(page) {
  * @description 미디어 카테고리, 콘텐츠를 리스트 형식으로 렌더링하는 함수
  */
 function renderGridMedia(page) {
-    const media = mediaListData.data;
+    const media = mediaList.data;
     const gridListDOM = document.querySelector(".media-contents__grid-list");
 
     let mediaListDOMString = '';
@@ -179,7 +176,7 @@ function renderListMedia(categoryIdx, mediaIdx) {
     const contentsString = getSelectedCategoryContentsDOMString(category[categoryIdx].media[mediaIdx]);
     contentsBoxDOM.innerHTML = contentsString;
 
-    const media = mediaListData.data.find((_data) => _data.id === category[categoryIdx].media[mediaIdx].id);
+    const media = mediaList.findMediaById(category[categoryIdx].media[mediaIdx].id);
     subscribedMediaList.setCallback(() => renderListMedia(categoryIdx, mediaIdx));
     setSubscribeButtonEvent(media, (mediaId) => renderSubscribedMedia(mediaId));
 }
@@ -284,7 +281,7 @@ function clickGridNavigationButton(step) {
     const gridBoxDOM = document.querySelector(".media-contents__grid-box");
     const currentPage = parseInt(gridBoxDOM.dataset.gridPage);
 
-    const mediaLength = mediaListData.length;
+    const mediaLength = mediaList.getLength();
     const nextPage = getBoundNumber(currentPage + step, 0, Math.floor((mediaLength - 1) / DATA_COUNT_PER_GRID));
 
     gridBoxDOM.dataset.gridPage = nextPage;
@@ -301,5 +298,5 @@ function clickGridList(e) {
         return;
     }
 
-    return clickGridItem(e, mediaListData.data, (mediaId) => renderSubscribedMedia(mediaId));
+    return clickGridItem(e, (mediaId) => renderSubscribedMedia(mediaId));
 }

--- a/media-contents/total-media.js
+++ b/media-contents/total-media.js
@@ -1,5 +1,4 @@
 import { subscribedMediaList } from "../store/subscribed-media.js";
-import { getData } from "../utils/fetch.js";
 import { getBoundNumber } from "../utils/get-number.js";
 import { mediaList } from "../store/media-list.js";
 import { DATA_COUNT_PER_GRID, DEFAULT_CATEGORY_INDEX, DEFAULT_MEDIA_INDEX, DEFAULT_PAGE } from "./constant.js";
@@ -13,15 +12,12 @@ import {
     getGridMediaItem,
     clickGridItem,
 } from "./util.js";
-
-let categoryData = {};
+import { mediaCategory } from "../store/media-category.js";
 
 /**
  * @description 전체 언론사를 렌더링하는 함수
  */
 export async function renderTotalMedia() {
-    categoryData = await getData('../static/data/media-by-category.json');
-
     const displayMode = getDisplayMode();
 
     const gridBoxDOM = document.querySelector(".media-contents__grid-box");
@@ -140,7 +136,7 @@ function renderGridMedia(page) {
  * @description 미디어 카테고리, 콘텐츠를 리스트 형식으로 렌더링하는 함수
  */
 function renderListMedia(categoryIdx, mediaIdx) {
-    const category = categoryData.data;
+    const category = mediaCategory.data;
     const categoryListDOM = document.querySelector(".media-contents__category-list");
 
     /**
@@ -228,7 +224,7 @@ function navigatePrevMedia() {
  * @description 리스트 보기에서 prev, next 버튼 클릭 동작을 수행하는 함수
  */
 function clickListNavigationButton(step) {
-    const category = categoryData.data;
+    const category = mediaCategory.data;
     const selectedCategory = document.querySelector(".media-contents__category-item--selected");
 
     const selectedCategoryIdx = parseInt(selectedCategory.dataset.selectedCategoryIdx);
@@ -248,7 +244,7 @@ function clickListNavigationButton(step) {
             /**
              * 첫 카테고리에 다다른 경우 마지막 카테고리로 이동
              */
-            const categoryIdx = categoryData.length - 1;
+            const categoryIdx = mediaCategory.getLength() - 1;
             selectedCategory.dataset.selectedCategoryIdx = categoryIdx;
             selectedCategory.dataset.selectedMediaIdx = category[categoryIdx].length - 1;
         } else {
@@ -257,7 +253,7 @@ function clickListNavigationButton(step) {
         }
     } else if (nextMediaIdx === currentCategory.length) {
         const nextCategoryIdx = selectedCategoryIdx + 1;
-        if (nextCategoryIdx === categoryData.length) {
+        if (nextCategoryIdx === mediaCategory.getLength()) {
             /**
              * 마지막 카테고리에 다다른 경우 첫 카테고리로 이동
              */

--- a/media-contents/total-media.js
+++ b/media-contents/total-media.js
@@ -103,7 +103,8 @@ function setArrowDisplayInGrid(page) {
     const prevMediaButton = document.querySelector(".media-contents__left-button");
     const nextMediaButton = document.querySelector(".media-contents__right-button");
 
-    const maxPage = Math.floor((mediaListData.data.length - 1) / DATA_COUNT_PER_GRID);
+    const lastPage = Math.floor((mediaListData.data.length - 1) / DATA_COUNT_PER_GRID);
+    const maxPage = lastPage >= 4 ? 3 : lastPage;
 
     if (page === 0) {
         prevMediaButton.classList.add("non-display");

--- a/media-contents/total-media.js
+++ b/media-contents/total-media.js
@@ -1,6 +1,7 @@
 import { subscribedMediaList } from "../store/subscribed-media.js";
 import { getData } from "../utils/fetch.js";
 import { getBoundNumber } from "../utils/get-number.js";
+import { shuffleList } from "../utils/shuffle-list.js";
 import { DATA_COUNT_PER_GRID, DEFAULT_CATEGORY_INDEX, DEFAULT_MEDIA_INDEX, DEFAULT_PAGE } from "./constant.js";
 import { 
     getSelectedCategoryItemDOMString, 
@@ -21,6 +22,7 @@ let mediaListData = {};
 export async function renderTotalMedia() {
     categoryData = await getData('../static/data/media-by-category.json');
     mediaListData = await getData('../static/data/media.json');
+    mediaListData.data = shuffleList(mediaListData.data.slice());
 
     const displayMode = getDisplayMode();
 

--- a/media-contents/total-media.js
+++ b/media-contents/total-media.js
@@ -3,6 +3,7 @@ import { getData } from "../utils/fetch.js";
 import { getBoundNumber } from "../utils/get-number.js";
 import { shuffleList } from "../utils/shuffle-list.js";
 import { DATA_COUNT_PER_GRID, DEFAULT_CATEGORY_INDEX, DEFAULT_MEDIA_INDEX, DEFAULT_PAGE } from "./constant.js";
+import { renderSubscribedMedia } from "./subscribed-media.js";
 import { 
     getSelectedCategoryItemDOMString, 
     getUnselectedCategoryItemDOMString,
@@ -178,8 +179,9 @@ function renderListMedia(categoryIdx, mediaIdx) {
     const contentsString = getSelectedCategoryContentsDOMString(category[categoryIdx].media[mediaIdx]);
     contentsBoxDOM.innerHTML = contentsString;
 
+    const media = mediaListData.data.find((_data) => _data.id === category[categoryIdx].media[mediaIdx].id);
     subscribedMediaList.setCallback(() => renderListMedia(categoryIdx, mediaIdx));
-    setSubscribeButtonEvent(category[categoryIdx].media[mediaIdx]);
+    setSubscribeButtonEvent(media, (mediaId) => renderSubscribedMedia(mediaId));
 }
 
 /**
@@ -299,5 +301,5 @@ function clickGridList(e) {
         return;
     }
 
-    return clickGridItem(e, mediaListData.data);
+    return clickGridItem(e, mediaListData.data, (mediaId) => renderSubscribedMedia(mediaId));
 }

--- a/media-contents/util.js
+++ b/media-contents/util.js
@@ -67,7 +67,9 @@ export function getSelectedCategoryContentsDOMString(media) {
 
     <section class="flexbox__flex-start--start gap32">
         <a class="media-contents__image-content flexbox__column-direction gap16" href="${imageContent.url}" target="_blank">
-            <img alt="뉴스 이미지" src="${imageContent.imageUrl}" />
+            <section class="media-contents__image-wrapper">
+                <img alt="뉴스 이미지" src="${imageContent.imageUrl}" />
+            </section>
             <p class="media-contents__image-headline text__medium16 text--strong">${imageContent.headline}</p>
         </a>
         <section class="flexbox__column-direction gap16">

--- a/media-contents/util.js
+++ b/media-contents/util.js
@@ -1,3 +1,4 @@
+import { mediaList } from "../store/media-list.js";
 import { subscribedMediaList } from "../store/subscribed-media.js";
 import { renderAlert } from "../utils/render-alert.js";
 import { renderSnackbar } from "../utils/render-snackbar.js";
@@ -163,7 +164,8 @@ export function getGridMediaItem(media) {
 /**
  * @description 그리드 보기에서 구독/구독취소 이벤트 등록하는 함수
  */
-export function clickGridItem(e, media, navigateToSubscribedMedia) {
+export function clickGridItem(e, navigateToSubscribedMedia) {
+    const media = mediaList.data;
     const mediaId = getMediaId(e.target);
 
     if (mediaId === -1) {

--- a/media-contents/util.js
+++ b/media-contents/util.js
@@ -1,6 +1,8 @@
 import { subscribedMediaList } from "../store/subscribed-media.js";
 import { renderAlert } from "../utils/render-alert.js";
 import { renderSnackbar } from "../utils/render-snackbar.js";
+import { setListDisplay } from "./media-display.js";
+import { setSubscribedMedia } from "./media-filter.js";
 
 /**
  * @description 선택된 카테고리 아이템 DOM string을 반환해주는 함수
@@ -87,10 +89,10 @@ export function getSelectedCategoryContentsDOMString(media) {
 /**
  * @description 구독/구독취소 이벤트 등록하는 함수
  */
-export function setSubscribeButtonEvent(media) {
+export function setSubscribeButtonEvent(media, navigateToSubscribedMedia) {
     const subscribeButtonDOM = document.querySelector(`.subscribe-button__${media.id}--subscribe`);
     if (subscribeButtonDOM) {
-        subscribeButtonDOM.addEventListener("click", () => clickSubscribeButton(media));
+        subscribeButtonDOM.addEventListener("click", () => clickSubscribeButton(media, () => clickSubscribeButtonCallback(media, navigateToSubscribedMedia)));
     }
 
     const unsubscribeButtonDOM = document.querySelector(`.subscribe-button__${media.id}--unsubscribe`);
@@ -102,9 +104,9 @@ export function setSubscribeButtonEvent(media) {
 /**
  * @description 언론사 구독 이벤트 등록하는 함수
  */
-function clickSubscribeButton(media) {
+function clickSubscribeButton(media, closeCallback) {
     subscribedMediaList.addMedia(media)
-    renderSnackbar("내가 구독한 언론사에 추가되었습니다.", 'subscribe');
+    renderSnackbar("내가 구독한 언론사에 추가되었습니다.", 'subscribe', closeCallback);
 }
 /**
  * @description 언론사 구독 취소 이벤트 등록하는 함수
@@ -159,7 +161,7 @@ export function getGridMediaItem(media) {
 /**
  * @description 그리드 보기에서 구독/구독취소 이벤트 등록하는 함수
  */
-export function clickGridItem(e, media) {
+export function clickGridItem(e, media, navigateToSubscribedMedia) {
     const mediaId = getMediaId(e.target);
 
     if (mediaId === -1) {
@@ -172,7 +174,17 @@ export function clickGridItem(e, media) {
     if (isSubscribed) {
         clickUnsubscribeButton(subscribedMedia);
     } else {
-        clickSubscribeButton(subscribedMedia);
+        clickSubscribeButton(subscribedMedia, () => clickSubscribeButtonCallback(subscribedMedia, navigateToSubscribedMedia));
+    }
+}
+/**
+ * @description 내가 구독한 언론사로 이동하는 함수
+ */
+function clickSubscribeButtonCallback(media, navigateToSubscribedMedia) {
+    if (navigateToSubscribedMedia) {
+        setListDisplay();
+        setSubscribedMedia();
+        navigateToSubscribedMedia(media.id);
     }
 }
 

--- a/setting/index.js
+++ b/setting/index.js
@@ -1,6 +1,6 @@
 import { renderDarkmode } from "./dark-mode.js";
 
-export function initSetting() {
+function initSetting() {
     renderDarkmode();
 }
 

--- a/store/media-category.js
+++ b/store/media-category.js
@@ -1,0 +1,15 @@
+class MediaCategory {
+    constructor() {
+        this.data = [];
+    }
+
+    setData(data) {
+        this.data = data;
+    }
+    getLength() {
+        return this.data.length;
+    }
+}
+
+const mediaCategory = new MediaCategory();
+export { mediaCategory };

--- a/store/media-detail.js
+++ b/store/media-detail.js
@@ -1,0 +1,15 @@
+class MediaDetail {
+    constructor() {
+        this.data = [];
+    }
+
+    setData(data) {
+        this.data = data;
+    }
+    findMediaById(id) {
+        return this.data.find((_data) => _data.id === id);
+    }
+}
+
+const mediaDetail = new MediaDetail();
+export { mediaDetail };

--- a/store/media-list.js
+++ b/store/media-list.js
@@ -1,0 +1,18 @@
+class MediaList {
+    constructor() {
+        this.data = [];
+    }
+
+    setData(data) {
+        this.data = data;
+    }
+    getLength() {
+        return this.data.length;
+    }
+    findMediaById(id) {
+        return this.data.find((_data) => _data.id === id);
+    }
+}
+
+const mediaList = new MediaList();
+export { mediaList };

--- a/store/subscribed-media.js
+++ b/store/subscribed-media.js
@@ -1,6 +1,85 @@
 class SubscribedMedia {
     constructor() {
-        this.data = [];
+        this.data = [{
+            "id": 1,
+            "icon": "./static/media-icon/media-icon-1.svg",
+            "name": "서울경제"
+        },
+        {
+            "id": 2,
+            "icon": "./static/media-icon/media-icon-2.svg",
+            "name": "데일리안"
+        },
+        {
+            "id": 3,
+            "icon": "./static/media-icon/media-icon-3.svg",
+            "name": "헤럴드경제"
+        },
+        {
+            "id": 4,
+            "icon": "./static/media-icon/media-icon-4.svg",
+            "name": "SBS Biz"
+        },
+        {
+            "id": 5,
+            "icon": "./static/media-icon/media-icon-5.svg",
+            "name": "세계일보"
+        },
+        {
+            "id": 6,
+            "icon": "./static/media-icon/media-icon-6.svg",
+            "name": "아시아경제"
+        },
+        {
+            "id": 7,
+            "icon": "./static/media-icon/media-icon-7.svg",
+            "name": "이데일리"
+        },
+        {
+            "id": 8,
+            "icon": "./static/media-icon/media-icon-8.svg",
+            "name": "한국일보"
+        },
+        {
+            "id": 9,
+            "icon": "./static/media-icon/media-icon-9.svg",
+            "name": "아이뉴스24"
+        },
+        {
+            "id": 10,
+            "icon": "./static/media-icon/media-icon-10.svg",
+            "name": "파이낸셜뉴스"
+        },
+        {
+            "id": 11,
+            "icon": "./static/media-icon/media-icon-11.svg",
+            "name": "스포츠서울"
+        },
+        {
+            "id": 12,
+            "icon": "./static/media-icon/media-icon-12.svg",
+            "name": "스포츠동아"
+        },
+        {
+            "id": 13,
+            "icon": "./static/media-icon/media-icon-13.svg",
+            "name": "석간문화일보"
+        },
+        {
+            "id": 14,
+            "icon": "./static/media-icon/media-icon-14.svg",
+            "name": "KBS WORLD"
+        },
+        {
+            "id": 15,
+            "icon": "./static/media-icon/media-icon-15.svg",
+            "name": "Korea JoongAng Daily"
+        },
+        {
+            "id": 16,
+            "icon": "./static/media-icon/media-icon-16.svg",
+            "name": "Insight"
+        }];
         this.callback = null;
     }
 

--- a/utils/render-snackbar.js
+++ b/utils/render-snackbar.js
@@ -2,7 +2,7 @@
 /**
  * @description snackbar를 렌더하는 함수
  */
-export function renderSnackbar(text, id) {
+export function renderSnackbar(text, id, closeCallback) {
     const bodyDOM = document.querySelector("body");
     const snackbarDOMString = `
     <section id="snackbar-${id}" class="snackbar__wrapper">
@@ -21,6 +21,7 @@ export function renderSnackbar(text, id) {
     snackbarId = setTimeout(() => {
         bodyDOM.removeChild(snackbarWrapperDOM);
         snackbarId = null;
+        closeCallback();
     }, 5000);
 
     /**
@@ -39,5 +40,6 @@ export function renderSnackbar(text, id) {
 
         const bodyDOM = document.querySelector("body");
         bodyDOM.removeChild(snackbarWrapperDOM);
+        closeCallback();
     }
 }

--- a/utils/shuffle-list.js
+++ b/utils/shuffle-list.js
@@ -1,0 +1,17 @@
+/**
+ * @description 리스트의 순서를 섞어서 반환하는 함수 (Fisher-Yates 셔플 함수)
+ * 
+ * @returns [1, 2, 3] -> [2, 1, 3]
+ */
+export function shuffleList(list) {
+    let currentIndex = list.length, randomIndex;
+
+    while (currentIndex !== 0) {
+        randomIndex = Math.floor(Math.random() * currentIndex);
+        currentIndex -= 1;
+
+        [list[currentIndex], list[randomIndex]] = [list[randomIndex], list[currentIndex]];
+    }
+
+    return list;
+}


### PR DESCRIPTION
## ✔️ 구현 사항
- 로고 클릭 시 새로고침
- 그리드 최대 페이지 4로 제한
- 전체 언론사 목록 무작위로 나오도록 하기
- 구독하기 버튼 클릭 후 내가 구독한 언론사 페이지로 이동
- 이미지 overflow hidden 설정
- 객체 -> store로 구현 수정
  - media list
  - media detial
  - category list
- progress bar 포커스

## ❓ 고민한 사항
### 1️⃣ 언론사 순서를 랜덤하게 배치하기

내가 구독한 언론사의 경우 데이터가 1차원 배열이기 때문에 데이터를 받아오고 바로 섞어서 재사용하면 된다. 그런데 문제는 전체 언론사이다. 전체 언론사는 카테고리 내에 있는 언론사 목록이 섞여야하는 것이다. 그럼 처음 데이터 받아왔을 때 섞어서 저장하면 되기는 하는데,,, 렌더링 함수 서두에 데이터만 딱 받아오고 객체에 저장해둔 뒤에 이후 로직들에서 사용하는 방식이 2차원 shuffle 로직으로 인해서 데이터 받아오는 부분이 방대해지면서 뭔가,,, 마음에 안 들었다. 

그래서 생각해본 방식이 데이터를 스토어에 전역으로 저장 & 첫 렌더링 시에 데이터 패칭을 해서 전역적으로 재사용할 수 있게 만드는 방식이다. 앞서 구독 목록을 store로 저장했었기 때문에 큰 틀은 바꾸지 않았다.

```jsx
class MediaList {
    constructor() {
        this.data = [];
    }

    setData(data) {
        this.data = data;
    }
    getLength() {
        return this.data.length;
    }
    findMediaById(id) {
        return this.data.find((_data) => _data.id === id);
    }
}

const mediaList = new MediaList();
export { mediaList };
```

클래스를 스토어로 해서 데이터를 저장해둔다.

```jsx
/**
 * @description 데이터를 패치하는 함수
 */
export async function getMediaData() {
    /**
     * media 목록
     */
    const mediaListData = await getData('../static/data/media.json');
    const shuffledMediaList = shuffleList(mediaListData.data.slice());
    mediaList.setData(shuffledMediaList);

    ...
    
    /**
     * 카테고리별 언론사 목록
     */
    const categoryData = await getData('../static/data/media-by-category.json');
    const shuffledCategory = categoryData.data.map((_data) => {
        const shuffledMediaList = shuffleList(_data.media.slice());
        return {
            ..._data,
            media: shuffledMediaList
        }
    });
    mediaCategory.setData(shuffledCategory);
}
```

이런 식으로 데이터를 한 번에 불러오고 스토어에 저장해서 사용하면 데이터 패치도 딱 한 번만 하고, 셔플 로직도 바로 사용해도 따로 분리되어 있으니까 코드 가독성에 크게 문제가 되지 않아서 여러모로 편해졌다.

### 2️⃣ Progress bar 자동 포커스 기능


https://github.com/jhj2713/fe-newsstand/assets/76840145/6ac0c91e-9bbd-4dbf-a22e-c63ea945f021



내가 구독한 언론사가 많아졌을 때, Progress bar가 보일 수 있도록 자동으로 스크롤해주는 기능을 구현하려고 한다. 

<img width="1051" alt="스크린샷 2024-07-11 오후 5 47 28" src="https://github.com/jhj2713/fe-newsstand/assets/76840145/1a61f626-3b8e-4576-8b87-08887a9cede2">

우선 현재 카테고리 박스 내부에서의 x(left) 좌표를 구하고 싶어서 progress bar의 left(주황색 범위)에서 카테고리의 left(연두색 범위)를 빼서 박스 내부 x(빨간색 범위) 좌표를 구할 수 있었다.

```jsx
selectedMediaDOM.getBoundingClientRect().left - categoryListDOM.getBoundingClientRect().left;
```

박스 내부 x 좌표에서 카테고리 박스의 width를 빼주면 overflow된 만큼의 영역이 계산된다.

```jsx
selectedMediaDOM.getBoundingClientRect().left - categoryListDOM.getBoundingClientRect().left - categoryListDOM.getBoundingClientRect().width;
```

overflow된 영역에 progress bar의 width(파란색 범위)만큼 더해줘야 해당 progress bar가 모두 보일 수 있기 때문에 progress bar의 width 만큼 더해주면 이동해야하는 스크롤 좌표가 나온다. 해당 좌표를 `scrollBy`의 left 속성에 넣어주면 자동으로 progress bar가 포커스 된다.

```jsx
const { width: selectedMediaWidth, left: selectedMediaLeft } = selectedMediaDOM.getBoundingClientRect();
const { width: categoryListWidth, left: categoryListLeft } = categoryListDOM.getBoundingClientRect();

const scroll = selectedMediaLeft - categoryListLeft - categoryListWidth + selectedMediaWidth;
categoryListDOM.scrollBy({ left: scroll });
```